### PR TITLE
Protect the canary

### DIFF
--- a/internals.go
+++ b/internals.go
@@ -44,6 +44,9 @@ func createCanary() []byte {
 	c := getRandBytes(32)
 	subtle.ConstantTimeCopy(1, memory[pageSize+roundedLen-32:pageSize+roundedLen], c)
 
+	// Mark the middle page as read-only.
+	memcall.Protect(memory[pageSize:pageSize+roundedLen], true, false)
+
 	// Return a slice that describes the correct portion of memory.
 	return getBytes(uintptr(unsafe.Pointer(&memory[pageSize+roundedLen-32])), 32)
 }

--- a/memguard.go
+++ b/memguard.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// A slice that holds the canary we set.
-	canary = getRandBytes(32)
+	canary = createCanary()
 )
 
 /*
@@ -77,8 +77,8 @@ func New(length int, readOnly bool) (*LockedBuffer, error) {
 	memcall.Protect(memory[:pageSize], false, false)
 	memcall.Protect(memory[pageSize+roundedLength:], false, false)
 
-	// Generate and set the canary.
-	copy(memory[pageSize+roundedLength-length-32:pageSize+roundedLength-length], canary)
+	// Set the canary.
+	subtle.ConstantTimeCopy(1, memory[pageSize+roundedLength-length-32:pageSize+roundedLength-length], canary)
 
 	// Set Buffer to a byte slice that describes the reigon of memory that is protected.
 	b.Buffer = getBytes(uintptr(unsafe.Pointer(&memory[pageSize+roundedLength-length])), length)


### PR DESCRIPTION
This PR aims to implement protection for the global canary value.

The container it is now stored in is basically a LockedBuffer but without a canary of its own, as that seemed a little cyclic.