### PR TITLE
Use finalizers to prevent leaks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,9 @@
 Awn Umar <awn@cryptolosophy.io>
     - Main developer.
 
+Carlo Alberto Ferraris <cafxx@strayorange.com>
+    - Implemented buffer leaking protection via finalizers.
+
 dotcppfile <dotcppfile@gmail.com>
     - Implemented guard pages.
     - Various bug fixes and optimisations.

--- a/internals.go
+++ b/internals.go
@@ -15,7 +15,7 @@ var (
 	catchInterruptOnce sync.Once
 
 	// Store pointers to all of the LockedBuffers.
-	allLockedBuffers      []*LockedBuffer
+	allLockedBuffers      []*lockedBuffer
 	allLockedBuffersMutex = &sync.Mutex{}
 
 	// Grab the system page size.
@@ -57,7 +57,7 @@ func roundToPageSize(length int) int {
 }
 
 // Get a slice that describes all memory related to a LockedBuffer.
-func getAllMemory(b *LockedBuffer) []byte {
+func getAllMemory(b *lockedBuffer) []byte {
 	// Calculate the length of the buffer and the associated rounded value.
 	bufLen, roundedBufLen := len(b.Buffer), roundToPageSize(len(b.Buffer)+32)
 

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -519,29 +519,30 @@ func TestFinalizer(t *testing.T) {
 	}
 	ic := c.lockedBuffer
 
-	runtime.GC()
-	for ib.IsDestroyed() != true {
-		runtime.Gosched()
-	}
-
-	if ib.IsDestroyed() != true {
-		t.Error("expected b to be destroyed")
+	if ib.IsDestroyed() != false {
+		t.Error("expected b to not be destroyed")
 	}
 	if ic.IsDestroyed() != false {
 		t.Error("expected c to not be destroyed")
 	}
 
-	runtime.KeepAlive(c)
+	runtime.KeepAlive(b)
+	// b is now unreachable
 
-	runtime.GC()
-	for ic.IsDestroyed() != true {
+	runtime.GC() // should collect b
+	for ib.IsDestroyed() != true {
 		runtime.Gosched()
 	}
 
-	if ib.IsDestroyed() != true {
-		t.Error("expected b to be destroyed")
+	if ic.IsDestroyed() != false {
+		t.Error("expected c to not be destroyed")
 	}
-	if ic.IsDestroyed() != true {
-		t.Error("expected c to be destroyed")
+
+	runtime.KeepAlive(c)
+	// c is now unreachable
+
+	runtime.GC() // should collect c
+	for ic.IsDestroyed() != true {
+		runtime.Gosched()
 	}
 }


### PR DESCRIPTION
As suggested in https://www.reddit.com/r/golang/comments/6s84ky/memory_security_in_go/dlcmzp3/

Some cosmetic/ux changes may be needed. `LockedBuffers()` was removed to allow implementing automatic destruction. This shouldn't be much of a problem since I can't think of any good use cases outside of `DeleteAll()`.