### PR TITLE
Add Buffer() method.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,5 @@
 We accept contributions from anyone. Here is the general process:
 
 1. Make a fork of the repository.
-2. Make your changes.
-3. If you're a first-time contributor, also add yourself to the [`AUTHORS`](/AUTHORS) file (in alphabetical order).
-4. Open a PR against the `development` branch.
+2. Make your changes. If you're a first-time contributor, also add yourself to the [`AUTHORS`](/AUTHORS) file (in alphabetical order).
+3. Open a PR against the `development` branch.

--- a/docs.go
+++ b/docs.go
@@ -15,7 +15,7 @@ The general working cycle is as follows:
     encryptionKey.Move([]byte("yellow submarine"))
 
     // Use the buffer wherever you need it.
-    Encrypt(encryptionKey.Buffer, plaintext)
+    Encrypt(encryptionKey.Buffer(), plaintext)
 
 The number of LockedBuffers that you are able to create is limited by how much memory your system kernel allows each process to mlock/VirtualLock. Therefore you should call Destroy on LockedBuffers that you no longer need, or simply defer a Destroy call after creating a new LockedBuffer.
 
@@ -29,7 +29,7 @@ If a function that you're using requires an array, you can cast the Buffer to an
 
     // Make sure the size of the array matches the size of the Buffer.
     // In this case that size is 16. This is very important.
-    keyArrayPtr := (*[16]byte)(unsafe.Pointer(&key.Buffer[0]))
+    keyArrayPtr := (*[16]byte)(unsafe.Pointer(&key.Buffer()[0]))
 
 The MemGuard API is thread-safe. You can extend this thread-safety to outside of the API functions by using the Mutex that each LockedBuffer exposes. Don't use the mutex when calling a function that is part of the MemGuard API though, or the process will deadlock.
 

--- a/internals.go
+++ b/internals.go
@@ -24,11 +24,12 @@ var (
 
 // container implements the actual data container.
 type container struct {
-	sync.Mutex
-	Buffer []byte
+	sync.Mutex // Local mutex lock.
 
-	readOnly  bool
-	destroyed bool
+	buffer []byte // Slice that references protected memory.
+
+	readOnly  bool // Is this memory read-only?
+	destroyed bool // Is this LockedBuffer destroyed?
 }
 
 // finaliserHint is a value that we monitor instead of the LockedBuffer
@@ -72,10 +73,10 @@ func roundToPageSize(length int) int {
 // Get a slice that describes all memory related to a LockedBuffer.
 func getAllMemory(b *container) []byte {
 	// Calculate the length of the buffer and the associated rounded value.
-	bufLen, roundedBufLen := len(b.Buffer), roundToPageSize(len(b.Buffer)+32)
+	bufLen, roundedBufLen := len(b.buffer), roundToPageSize(len(b.buffer)+32)
 
 	// Calculate the address of the start of the memory.
-	memAddr := uintptr(unsafe.Pointer(&b.Buffer[0])) - uintptr((roundedBufLen-bufLen)+pageSize)
+	memAddr := uintptr(unsafe.Pointer(&b.buffer[0])) - uintptr((roundedBufLen-bufLen)+pageSize)
 
 	// Calculate the size of the entire memory.
 	memLen := (pageSize * 2) + roundedBufLen

--- a/memguard.go
+++ b/memguard.go
@@ -18,9 +18,12 @@ var (
 )
 
 /*
-LockedBuffer is a structure that holds secure values. It
-exposes a Mutex, various metadata flags, and a slice that
-maps to the protected memory.
+LockedBuffer is a structure that holds secure values.
+
+The protected memory itself can be accessed with the `Buffer()`
+method. The varous status flags can be accessed with the
+`IsDestroyed()` and `IsReadOnly()` methods, both of which
+are pretty self-explanatory.
 
 The number of LockedBuffers that you are able to create is
 limited by how much memory your system kernel allows each

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -13,8 +13,8 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error")
 	}
-	if len(b.Buffer) != 8 || cap(b.Buffer) != 8 {
-		t.Error("length or capacity != required; len, cap =", len(b.Buffer), cap(b.Buffer))
+	if len(b.Buffer()) != 8 || cap(b.Buffer()) != 8 {
+		t.Error("length or capacity != required; len, cap =", len(b.Buffer()), cap(b.Buffer()))
 	}
 	b.Destroy()
 
@@ -41,8 +41,8 @@ func TestNewFromBytes(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error")
 	}
-	if !bytes.Equal(b.Buffer, []byte("test")) {
-		t.Error("b.Buffer != required")
+	if !bytes.Equal(b.Buffer(), []byte("test")) {
+		t.Error("b.Buffer() != required")
 	}
 	b.Destroy()
 
@@ -67,7 +67,7 @@ func TestNewFromBytes(t *testing.T) {
 func TestNewRandom(t *testing.T) {
 	b, _ := NewRandom(32, false)
 
-	if bytes.Equal(b.Buffer, make([]byte, 32)) {
+	if bytes.Equal(b.Buffer(), make([]byte, 32)) {
 		t.Error("was not filled with random data")
 	}
 
@@ -89,6 +89,15 @@ func TestNewRandom(t *testing.T) {
 		t.Error("unexpected state")
 	}
 	a.Destroy()
+}
+
+func TestBuffer(t *testing.T) {
+	b, _ := New(8, false)
+	defer b.Destroy()
+
+	if !bytes.Equal(b.buffer, b.Buffer()) {
+		t.Error("buffers inequal")
+	}
 }
 
 func TestGetMetadata(t *testing.T) {
@@ -192,7 +201,7 @@ func TestMove(t *testing.T) {
 	if !bytes.Equal(buf, make([]byte, len(buf))) {
 		t.Error("expected buf to be nil")
 	}
-	if !bytes.Equal(b.Buffer, []byte("this is a very l")) {
+	if !bytes.Equal(b.Buffer(), []byte("this is a very l")) {
 		t.Error("bytes were't copied properly")
 	}
 	b.Destroy()
@@ -204,11 +213,11 @@ func TestMove(t *testing.T) {
 	if !bytes.Equal(buf, make([]byte, len(buf))) {
 		t.Error("expected buf to be nil")
 	}
-	if !bytes.Equal(b.Buffer[:len(buf)], []byte("diz small buf")) {
+	if !bytes.Equal(b.Buffer()[:len(buf)], []byte("diz small buf")) {
 		t.Error("bytes weren't copied properly")
 	}
-	if !bytes.Equal(b.Buffer[len(buf):], make([]byte, 16-len(buf))) {
-		t.Error("bytes were't copied properly;", b.Buffer[len(buf):])
+	if !bytes.Equal(b.Buffer()[len(buf):], make([]byte, 16-len(buf))) {
+		t.Error("bytes were't copied properly;", b.Buffer()[len(buf):])
 	}
 	b.Destroy()
 
@@ -219,7 +228,7 @@ func TestMove(t *testing.T) {
 	if !bytes.Equal(buf, make([]byte, len(buf))) {
 		t.Error("expected buf to be nil")
 	}
-	if !bytes.Equal(b.Buffer, []byte("yellow submarine")) {
+	if !bytes.Equal(b.Buffer(), []byte("yellow submarine")) {
 		t.Error("bytes were't copied properly")
 	}
 
@@ -241,15 +250,15 @@ func TestFillRandomBytes(t *testing.T) {
 	a, _ := New(32, false)
 	a.FillRandomBytes()
 
-	if a.Buffer == nil {
+	if a.Buffer() == nil {
 		t.Error("not random")
 	}
 
-	WipeBytes(a.Buffer)
+	WipeBytes(a.Buffer())
 	a.FillRandomBytesAt(16, 16)
 
-	if !bytes.Equal(a.Buffer[:16], make([]byte, 16)) || bytes.Equal(a.Buffer[16:], make([]byte, 16)) {
-		t.Error("incorrect offset/size;", a.Buffer[:16], a.Buffer[16:])
+	if !bytes.Equal(a.Buffer()[:16], make([]byte, 16)) || bytes.Equal(a.Buffer()[16:], make([]byte, 16)) {
+		t.Error("incorrect offset/size;", a.Buffer()[:16], a.Buffer()[16:])
 	}
 
 	a.MarkAsReadOnly()
@@ -272,7 +281,7 @@ func TestDestroyAll(t *testing.T) {
 
 	DestroyAll()
 
-	if b.Buffer != nil || c.Buffer != nil {
+	if b.Buffer() != nil || c.Buffer() != nil {
 		t.Error("expected buffers to be nil")
 	}
 
@@ -294,8 +303,8 @@ func TestConcatenate(t *testing.T) {
 		t.Error("unexpected error")
 	}
 
-	if !bytes.Equal(c.Buffer, []byte("xxxxyyyy")) {
-		t.Error("unexpected output;", c.Buffer)
+	if !bytes.Equal(c.Buffer(), []byte("xxxxyyyy")) {
+		t.Error("unexpected output;", c.Buffer())
 	}
 	if !c.IsReadOnly() {
 		t.Error("expected ReadOnly")
@@ -318,7 +327,7 @@ func TestDuplicate(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error")
 	}
-	if !bytes.Equal(b.Buffer, c.Buffer) {
+	if !bytes.Equal(b.Buffer(), c.Buffer()) {
 		t.Error("duplicated buffer has different contents")
 	}
 	if !c.IsReadOnly() {
@@ -370,16 +379,16 @@ func TestSplit(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error")
 	}
-	if !bytes.Equal(b.Buffer, []byte("xxxx")) {
+	if !bytes.Equal(b.Buffer(), []byte("xxxx")) {
 		t.Error("first buffer has unexpected value")
 	}
-	if !bytes.Equal(c.Buffer, []byte("yyyy")) {
+	if !bytes.Equal(c.Buffer(), []byte("yyyy")) {
 		t.Error("second buffer has unexpected value")
 	}
 	if !b.IsReadOnly() || !c.IsReadOnly() {
 		t.Error("permissions not preserved")
 	}
-	if !bytes.Equal(a.Buffer, []byte("xxxxyyyy")) {
+	if !bytes.Equal(a.Buffer(), []byte("xxxxyyyy")) {
 		t.Error("original is not preserved")
 	}
 
@@ -409,8 +418,8 @@ func TestTrim(t *testing.T) {
 		t.Error("unexpected error")
 	}
 
-	if !bytes.Equal(c.Buffer, []byte("xxyy")) {
-		t.Error("unexpected value:", c.Buffer)
+	if !bytes.Equal(c.Buffer(), []byte("xxyy")) {
+		t.Error("unexpected value:", c.Buffer())
 	}
 
 	if !c.IsReadOnly() {


### PR DESCRIPTION
The recent finaliser addition involved moving the LockedBuffer's own methods into a separate struct. This messed with the documentation generated by godoc, so this PR aims to rectify that.

We add an explicit `Buffer()` method that functions identically to the old `.Buffer` syntax.