### PR TITLE
Fix potential leak of canary value

### DIFF
--- a/memcall/memcall_osx.go
+++ b/memcall/memcall_osx.go
@@ -65,6 +65,6 @@ func Protect(b []byte, read, write bool) {
 func DisableCoreDumps() {
 	// Disable core dumps.
 	if err := unix.Setrlimit(unix.RLIMIT_CORE, &unix.Rlimit{Cur: 0, Max: 0}); err != nil {
-		panic(fmt.Sprintf("memguard.memprot._disableCoreDumps(): could not set rlimit [Err: %s]", err))
+		panic(fmt.Sprintf("memguard.memcall.DisableCoreDumps(): could not set rlimit [Err: %s]", err))
 	}
 }

--- a/memcall/memcall_unix.go
+++ b/memcall/memcall_unix.go
@@ -69,6 +69,6 @@ func Protect(b []byte, read, write bool) {
 func DisableCoreDumps() {
 	// Disable core dumps.
 	if err := unix.Setrlimit(unix.RLIMIT_CORE, &unix.Rlimit{Cur: 0, Max: 0}); err != nil {
-		panic(fmt.Sprintf("memguard.memprot._disableCoreDumps(): could not set rlimit [Err: %s]", err))
+		panic(fmt.Sprintf("memguard.memcall.DisableCoreDumps(): could not set rlimit [Err: %s]", err))
 	}
 }


### PR DESCRIPTION
Stop generating an ordinary slice (to initially store the canary value) to later copy from into the secure buffer. It defeats the purpose of the secure buffer.