### PR TITLE
Replace WipeBytes with a Wipe method.

### DIFF
--- a/internals.go
+++ b/internals.go
@@ -101,3 +101,12 @@ func fillRandBytes(b []byte) {
 		panic("memguard.csprng(): could not get random bytes")
 	}
 }
+
+// Wipes a byte slice with zeroes.
+func wipeBytes(buf []byte) {
+	// Iterate over the slice...
+	for i := 0; i < len(buf); i++ {
+		// ... setting each element to zero.
+		buf[i] = byte(0)
+	}
+}

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -254,7 +254,7 @@ func TestFillRandomBytes(t *testing.T) {
 		t.Error("not random")
 	}
 
-	WipeBytes(a.Buffer())
+	a.Wipe()
 	a.FillRandomBytesAt(16, 16)
 
 	if !bytes.Equal(a.Buffer()[:16], make([]byte, 16)) || bytes.Equal(a.Buffer()[16:], make([]byte, 16)) {
@@ -452,11 +452,15 @@ func TestCatchInterrupt(t *testing.T) {
 	}
 }
 
-func TestWipeBytes(t *testing.T) {
-	b := []byte("yellow submarine")
-	WipeBytes(b)
-	if !bytes.Equal(b, make([]byte, 16)) {
-		t.Error("bytes not wiped; b =", b)
+func TestWipe(t *testing.T) {
+	b, _ := NewFromBytes([]byte("yellow submarine"), false)
+
+	if err := b.Wipe(); err != nil {
+		t.Error("failed to wipe:", err)
+	}
+
+	if !bytes.Equal(b.Buffer(), make([]byte, 16)) {
+		t.Error("bytes not wiped; b =", b.Buffer())
 	}
 }
 


### PR DESCRIPTION
Exposing a function for wiping ordinary slices implies that it holds some kind of guarantees. In reality, wiping an ordinary slice is next to useless, since you have no idea about any copies made or what the garbage collector has done.

Instead, to only allow wiping of secure LockedBuffers, we make the WipeBytes function internal and instead expose a Wipe method for LockedBuffers.