### PR TITLE
memcall: handle openbsd explicitly

### DIFF
--- a/memcall/memcall_openbsd.go
+++ b/memcall/memcall_openbsd.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin,!openbsd
+// +build openbsd
 
 package memcall
 
@@ -10,9 +10,6 @@ import (
 
 // Lock is a wrapper for unix.Mlock(), with extra precautions.
 func Lock(b []byte) {
-	// Advise the kernel not to dump. Ignore failure.
-	unix.Madvise(b, unix.MADV_DONTDUMP)
-
 	// Call mlock.
 	if err := unix.Mlock(b); err != nil {
 		panic(fmt.Sprintf("memguard.memcall.Lock(): could not acquire lock on %p, limit reached? [Err: %s]", &b[0], err))
@@ -29,7 +26,7 @@ func Unlock(b []byte) {
 // Alloc allocates a byte slice of length n and returns it.
 func Alloc(n int) []byte {
 	// Allocate the memory.
-	b, err := unix.Mmap(-1, 0, n, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS)
+	b, err := unix.Mmap(-1, 0, n, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANON)
 	if err != nil {
 		panic(fmt.Sprintf("memguard.memcall.Alloc(): could not allocate [Err: %s]", err))
 	}

--- a/memcall/memcall_windows.go
+++ b/memcall/memcall_windows.go
@@ -29,7 +29,7 @@ func Unlock(b []byte) {
 // Alloc allocates a byte slice of length n and returns it.
 func Alloc(n int) []byte {
 	// Allocate the memory.
-	ptr, err := windows.VirtualAlloc(_zero, uintptr(n), 0x00001000|0x00002000, 0x04)
+	ptr, err := windows.VirtualAlloc(_zero, uintptr(n), 0x1000|0x2000, 0x4)
 	if err != nil {
 		panic(fmt.Sprintf("memguard.memcall.Alloc(): could not allocate [Err: %s]", err))
 	}
@@ -50,11 +50,11 @@ func Protect(b []byte, read, write bool) {
 	// Ascertain protection value from arguments.
 	var prot int
 	if write {
-		prot = 0x04 // PAGE_READWRITE
+		prot = 0x4 // PAGE_READWRITE
 	} else if read {
-		prot = 0x02 // PAGE_READ
+		prot = 0x2 // PAGE_READ
 	} else {
-		prot = 0x01 // PAGE_NOACCESS
+		prot = 0x1 // PAGE_NOACCESS
 	}
 
 	var oldProtect uint32


### PR DESCRIPTION
* Handle the platform `openbsd` explicitly.
* Use `MAP_PRIVATE` on Unix systems.

This fixes #45.