### PR TITLE
freebsd: add the MAP_NOCORE flag

### DIFF
--- a/memcall/memcall_freebsd.go
+++ b/memcall/memcall_freebsd.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin,!openbsd,!freebsd
+// +build freebsd
 
 package memcall
 
@@ -29,7 +29,7 @@ func Unlock(b []byte) {
 // Alloc allocates a byte slice of length n and returns it.
 func Alloc(n int) []byte {
 	// Allocate the memory.
-	b, err := unix.Mmap(-1, 0, n, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS)
+	b, err := unix.Mmap(-1, 0, n, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS|unix.MAP_NOCORE)
 	if err != nil {
 		panic(fmt.Sprintf("memguard.memcall.Alloc(): could not allocate [Err: %s]", err))
 	}


### PR DESCRIPTION
On freebsd, we have the option to tell the kernel at mmap time to disregard this memory when dumping to core files.