### PR TITLE
alloc: use strange bytes

### DIFF
--- a/container.go
+++ b/container.go
@@ -70,6 +70,9 @@ func newContainer(size int, mutable bool) (*LockedBuffer, error) {
 	// Set Buffer to a byte slice that describes the reigon of memory that is protected.
 	b.buffer = getBytes(uintptr(unsafe.Pointer(&memory[pageSize+roundedLength-size])), size)
 
+	// The buffer is filled with weird bytes so let's wipe it.
+	wipeBytes(b.buffer)
+
 	// Set appropriate mutability state.
 	b.mutable = true
 	if !mutable {

--- a/memcall/memcall_freebsd.go
+++ b/memcall/memcall_freebsd.go
@@ -34,6 +34,11 @@ func Alloc(n int) []byte {
 		panic(fmt.Sprintf("memguard.memcall.Alloc(): could not allocate [Err: %s]", err))
 	}
 
+	// Fill memory with weird bytes in order to help catch bugs due to uninitialized data.
+	for i := 0; i < n; i++ {
+		b[i] = byte(0xdb)
+	}
+
 	// Return the allocated memory.
 	return b
 }

--- a/memcall/memcall_openbsd.go
+++ b/memcall/memcall_openbsd.go
@@ -31,6 +31,11 @@ func Alloc(n int) []byte {
 		panic(fmt.Sprintf("memguard.memcall.Alloc(): could not allocate [Err: %s]", err))
 	}
 
+	// Fill memory with weird bytes in order to help catch bugs due to uninitialized data.
+	for i := 0; i < n; i++ {
+		b[i] = byte(0xdb)
+	}
+
 	// Return the allocated memory.
 	return b
 }

--- a/memcall/memcall_osx.go
+++ b/memcall/memcall_osx.go
@@ -30,6 +30,11 @@ func Alloc(n int) []byte {
 		panic(fmt.Sprintf("memguard.memcall.Alloc(): could not allocate [Err: %s]", err))
 	}
 
+	// Fill memory with weird bytes in order to help catch bugs due to uninitialized data.
+	for i := 0; i < n; i++ {
+		b[i] = byte(0xdb)
+	}
+
 	// Return the allocated memory.
 	return b
 }

--- a/memcall/memcall_test.go
+++ b/memcall/memcall_test.go
@@ -5,6 +5,14 @@ import "testing"
 func TestCycle(t *testing.T) {
 	DisableCoreDumps()
 	buffer := Alloc(32)
+
+	// Test if the whole memory is filled with 0xdb.
+	for i := 0; i < 32; i++ {
+		if buffer[i] != byte(0xdb) {
+			t.Error("unexpected byte:", buffer[i])
+		}
+	}
+
 	Protect(buffer, true, true)
 	Lock(buffer)
 	Unlock(buffer)

--- a/memcall/memcall_unix.go
+++ b/memcall/memcall_unix.go
@@ -34,6 +34,11 @@ func Alloc(n int) []byte {
 		panic(fmt.Sprintf("memguard.memcall.Alloc(): could not allocate [Err: %s]", err))
 	}
 
+	// Fill memory with weird bytes in order to help catch bugs due to uninitialized data.
+	for i := 0; i < n; i++ {
+		b[i] = byte(0xdb)
+	}
+
 	// Return the allocated memory.
 	return b
 }

--- a/memcall/memcall_windows.go
+++ b/memcall/memcall_windows.go
@@ -34,8 +34,16 @@ func Alloc(n int) []byte {
 		panic(fmt.Sprintf("memguard.memcall.Alloc(): could not allocate [Err: %s]", err))
 	}
 
+	// Convert into a byte slice.
+	b := _getBytes(ptr, n, n)
+
+	// Fill memory with weird bytes in order to help catch bugs due to uninitialized data.
+	for i := 0; i < n; i++ {
+		b[i] = byte(0xdb)
+	}
+
 	// Return the allocated memory.
-	return _getBytes(ptr, n, n)
+	return b
 }
 
 // Free unallocates the byte slice specified.


### PR DESCRIPTION
Like libsodium does, we now fill allocated region with 0xdb bytes in order to help catch bugs due to uninitialized data.