### PR TITLE
Added buffer cast types

### DIFF
--- a/memguard.go
+++ b/memguard.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"unsafe"
 
 	"github.com/awnumar/memguard/memcall"
 )
@@ -120,6 +121,24 @@ Make sure that you do not dereference the pointer and pass around the resulting 
 func (b *container) Buffer() []byte {
 	return b.buffer
 }
+
+//BufferPointer8 returns a pointer to the slice that references the secure, protected portion of memroy that has been cast to a [8]byte
+func (b *container) BufferPointer8() *[8]byte { return (*[8]byte)(unsafe.Pointer(&b.buffer[0])) }
+
+//BufferPointer12 returns a pointer to the slice that references the secure, protected portion of memroy that has been cast to a [12]byte
+func (b *container) BufferPointer12() *[12]byte { return (*[12]byte)(unsafe.Pointer(&b.buffer[0])) }
+
+//BufferPointer16 returns a pointer to the slice that references the secure, protected portion of memroy that has been cast to a [16]byte
+func (b *container) BufferPointer16() *[16]byte { return (*[16]byte)(unsafe.Pointer(&b.buffer[0])) }
+
+//BufferPointer32 returns a pointer to the slice that references the secure, protected portion of memroy that has been cast to a [32]byte
+func (b *container) BufferPointer32() *[32]byte { return (*[32]byte)(unsafe.Pointer(&b.buffer[0])) }
+
+//BufferPointer64 returns a pointer to the slice that references the secure, protected portion of memroy that has been cast to a [64]byte
+func (b *container) BufferPointer64() *[64]byte { return (*[64]byte)(unsafe.Pointer(&b.buffer[0])) }
+
+//BufferPointer returns a pointer to the slice that references the secure, protected portion of memory
+func (b *container) BufferPointer() *[]byte { return (*[]byte)(unsafe.Pointer(&b.buffer)) }
 
 /*
 IsMutable returns a boolean value indicating if a LockedBuffer is marked read-only.

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -113,6 +113,163 @@ func TestBuffer(t *testing.T) {
 	}
 }
 
+func TestBufferPointer8(t *testing.T) {
+	b, _ := NewImmutable(8)
+
+	if !bytes.Equal(b.buffer, b.Buffer()) {
+		t.Error("buffers inequal")
+	}
+	var buf interface{}
+	buf = b.BufferPointer8()
+
+	if _, ok := buf.(*[8]byte); !ok {
+		t.Error("Buffer wasn't cast to *[8]byte")
+	}
+
+	var buf2 interface{}
+	buf2 = *b.BufferPointer8()
+
+	if _, ok := buf2.([8]byte); !ok {
+		t.Error("Buffer wasn't cast to [8]byte")
+	}
+
+	b.Destroy()
+
+	if len(b.Buffer()) != 0 || cap(b.Buffer()) != 0 {
+		t.Error("expected zero length")
+	}
+}
+func TestBufferPointer12(t *testing.T) {
+	b, _ := NewImmutable(24)
+
+	if !bytes.Equal(b.buffer, b.Buffer()) {
+		t.Error("buffers inequal")
+	}
+	var buf interface{}
+	buf = b.BufferPointer12()
+
+	if _, ok := buf.(*[12]byte); !ok {
+		t.Error("Buffer wasn't cast to *[12]byte")
+	}
+
+	var buf2 interface{}
+	buf2 = *b.BufferPointer12()
+
+	if _, ok := buf2.([12]byte); !ok {
+		t.Error("Buffer wasn't cast to [12]byte")
+	}
+
+	b.Destroy()
+
+	if len(b.Buffer()) != 0 || cap(b.Buffer()) != 0 {
+		t.Error("expected zero length")
+	}
+}
+func TestBufferPointer16(t *testing.T) {
+	b, _ := NewImmutable(32)
+
+	if !bytes.Equal(b.buffer, b.Buffer()) {
+		t.Error("buffers inequal")
+	}
+	var buf interface{}
+	buf = b.BufferPointer16()
+
+	if _, ok := buf.(*[16]byte); !ok {
+		t.Error("Buffer wasn't cast to *[16]byte")
+	}
+
+	var buf2 interface{}
+	buf2 = *b.BufferPointer16()
+
+	if _, ok := buf2.([16]byte); !ok {
+		t.Error("Buffer wasn't cast to [16]byte")
+	}
+
+	b.Destroy()
+
+	if len(b.Buffer()) != 0 || cap(b.Buffer()) != 0 {
+		t.Error("expected zero length")
+	}
+}
+func TestBufferPointer32(t *testing.T) {
+	b, _ := NewImmutable(32)
+
+	if !bytes.Equal(b.buffer, b.Buffer()) {
+		t.Error("buffers inequal")
+	}
+	var buf interface{}
+	buf = b.BufferPointer32()
+
+	if _, ok := buf.(*[32]byte); !ok {
+		t.Error("Buffer wasn't cast to *[32]byte")
+	}
+
+	var buf2 interface{}
+	buf2 = *b.BufferPointer32()
+
+	if _, ok := buf2.([32]byte); !ok {
+		t.Error("Buffer wasn't cast to [32]byte")
+	}
+
+	b.Destroy()
+
+	if len(b.Buffer()) != 0 || cap(b.Buffer()) != 0 {
+		t.Error("expected zero length")
+	}
+}
+func TestBufferPointer64(t *testing.T) {
+	b, _ := NewImmutable(64)
+
+	if !bytes.Equal(b.buffer, b.Buffer()) {
+		t.Error("buffers inequal")
+	}
+	var buf interface{}
+	buf = b.BufferPointer64()
+
+	if _, ok := buf.(*[64]byte); !ok {
+		t.Error("Buffer wasn't cast to *[64]byte")
+	}
+
+	var buf2 interface{}
+	buf2 = *b.BufferPointer64()
+
+	if _, ok := buf2.([64]byte); !ok {
+		t.Error("Buffer wasn't cast to [64]byte")
+	}
+
+	b.Destroy()
+
+	if len(b.Buffer()) != 0 || cap(b.Buffer()) != 0 {
+		t.Error("expected zero length")
+	}
+}
+func TestBufferPointer(t *testing.T) {
+	b, _ := NewImmutable(8)
+
+	if !bytes.Equal(b.buffer, b.Buffer()) {
+		t.Error("buffers inequal")
+	}
+	var buf interface{}
+	buf = b.BufferPointer()
+
+	if _, ok := buf.(*[]byte); !ok {
+		t.Error("Buffer wasn't cast to *[]byte")
+	}
+
+	var buf2 interface{}
+	buf2 = *b.BufferPointer()
+
+	if _, ok := buf2.([]byte); !ok {
+		t.Error("Buffer wasn't cast to []byte")
+	}
+
+	b.Destroy()
+
+	if len(b.Buffer()) != 0 || cap(b.Buffer()) != 0 {
+		t.Error("expected zero length")
+	}
+}
+
 func TestGetMetadata(t *testing.T) {
 	b, _ := NewMutable(8)
 


### PR DESCRIPTION
Tried to reduce the amount of manually casting needed for buffer slices.
Added the return of a pointer to the byte slice as it makes it easier
to keep everything in the secure buffer.