### PR TITLE
v0.14.0

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,9 +5,11 @@ import "errors"
 // ErrDestroyed is returned when a function is called on a destroyed LockedBuffer.
 var ErrDestroyed = errors.New("memguard.ErrDestroyed: buffer is destroyed")
 
-// ErrImmutable is returned when a function that needs to modify a LockedBuffer
-// is given a LockedBuffer that is immutable.
+// ErrImmutable is returned when a function that needs to modify a LockedBuffer is given a LockedBuffer that is immutable.
 var ErrImmutable = errors.New("memguard.ErrImmutable: cannot modify immutable buffer")
 
 // ErrInvalidLength is returned when a LockedBuffer of smaller than one byte is requested.
 var ErrInvalidLength = errors.New("memguard.ErrInvalidLength: length of buffer must be greater than zero")
+
+// ErrInvalidConversion is returned when attempting to get a slice of a LockedBuffer that is of an inappropriate size for that slice type. For example, attempting to get a []uint16 representation of a LockedBuffer of length 9 bytes would trigger this error, since there would be a byte leftover after the conversion.
+var ErrInvalidConversion = errors.New("memguard.ErrInvalidConversion: length of buffer must align with target type")

--- a/memguard.go
+++ b/memguard.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"unsafe"
 
 	"github.com/awnumar/memguard/memcall"
 )
@@ -119,6 +120,235 @@ Make sure that you do not dereference the pointer and pass around the resulting 
 */
 func (b *container) Buffer() []byte {
 	return b.buffer
+}
+
+/*
+Uint8 returns a slice (of type []uint8) that references the secure, protected portion of memory.
+
+Uint8 is practically identical to Buffer, but it has been added for completeness' sake. Buffer will usually be the faster and easier option.
+*/
+func (b *container) Uint8() ([]uint8, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Return the slice.
+	return []uint8(b.buffer), nil
+}
+
+/*
+Uint16 returns a slice (of type []uint16) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 2 bytes in length, or else an error will be returned.
+*/
+func (b *container) Uint16() ([]uint16, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%2 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Perform the conversion.
+	var sl = struct {
+		addr uintptr
+		len  int
+		cap  int
+	}{uintptr(unsafe.Pointer(&b.buffer[0])), b.Size() / 2, b.Size() / 2}
+
+	// Return the new slice.
+	return *(*[]uint16)(unsafe.Pointer(&sl)), nil
+}
+
+/*
+Uint32 returns a slice (of type []uint32) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 4 bytes in length, or else an error will be returned.
+*/
+func (b *container) Uint32() ([]uint32, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%4 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Perform the conversion.
+	var sl = struct {
+		addr uintptr
+		len  int
+		cap  int
+	}{uintptr(unsafe.Pointer(&b.buffer[0])), b.Size() / 4, b.Size() / 4}
+
+	// Return the new slice.
+	return *(*[]uint32)(unsafe.Pointer(&sl)), nil
+}
+
+/*
+Uint64 returns a slice (of type []uint64) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 8 bytes in length, or else an error will be returned.
+*/
+func (b *container) Uint64() ([]uint64, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%8 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Perform the conversion.
+	var sl = struct {
+		addr uintptr
+		len  int
+		cap  int
+	}{uintptr(unsafe.Pointer(&b.buffer[0])), b.Size() / 8, b.Size() / 8}
+
+	// Return the new slice.
+	return *(*[]uint64)(unsafe.Pointer(&sl)), nil
+}
+
+/*
+Int8 returns a slice (of type []int8) that references the secure, protected portion of memory.
+*/
+func (b *container) Int8() ([]int8, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Perform the conversion.
+	var sl = struct {
+		addr uintptr
+		len  int
+		cap  int
+	}{uintptr(unsafe.Pointer(&b.buffer[0])), b.Size(), b.Size()}
+
+	// Return the new slice.
+	return *(*[]int8)(unsafe.Pointer(&sl)), nil
+}
+
+/*
+Int16 returns a slice (of type []int16) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 2 bytes in length, or else an error will be returned.
+*/
+func (b *container) Int16() ([]int16, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%2 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Perform the conversion.
+	var sl = struct {
+		addr uintptr
+		len  int
+		cap  int
+	}{uintptr(unsafe.Pointer(&b.buffer[0])), b.Size() / 2, b.Size() / 2}
+
+	// Return the new slice.
+	return *(*[]int16)(unsafe.Pointer(&sl)), nil
+}
+
+/*
+Int32 returns a slice (of type []int32) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 4 bytes in length, or else an error will be returned.
+*/
+func (b *container) Int32() ([]int32, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%4 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Perform the conversion.
+	var sl = struct {
+		addr uintptr
+		len  int
+		cap  int
+	}{uintptr(unsafe.Pointer(&b.buffer[0])), b.Size() / 4, b.Size() / 4}
+
+	// Return the new slice.
+	return *(*[]int32)(unsafe.Pointer(&sl)), nil
+}
+
+/*
+Int64 returns a slice (of type []int64) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 8 bytes in length, or else an error will be returned.
+*/
+func (b *container) Int64() ([]int64, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%8 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Perform the conversion.
+	var sl = struct {
+		addr uintptr
+		len  int
+		cap  int
+	}{uintptr(unsafe.Pointer(&b.buffer[0])), b.Size() / 8, b.Size() / 8}
+
+	// Return the new slice.
+	return *(*[]int64)(unsafe.Pointer(&sl)), nil
 }
 
 /*

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -100,7 +100,7 @@ func TestNewRandom(t *testing.T) {
 }
 
 func TestBuffer(t *testing.T) {
-	b, _ := NewImmutable(8)
+	b, _ := NewImmutableRandom(8)
 
 	if !bytes.Equal(b.buffer, b.Buffer()) {
 		t.Error("buffers inequal")
@@ -110,6 +110,223 @@ func TestBuffer(t *testing.T) {
 
 	if len(b.Buffer()) != 0 || cap(b.Buffer()) != 0 {
 		t.Error("expected zero length")
+	}
+}
+
+func TestUint8(t *testing.T) {
+	b, _ := NewImmutableRandom(8)
+
+	x, err := b.Uint8()
+	if err != nil {
+		t.Error("unexpected error")
+	}
+	if !bytes.Equal(b.buffer, x) {
+		t.Error("conversion failed")
+	}
+
+	if &b.buffer[0] != &x[0] {
+		t.Error("conversion points incorrectly")
+	}
+	if len(x) != 8 || cap(x) != 8 {
+		t.Error("unexpected length or capacity")
+	}
+
+	b.Destroy()
+
+	if _, err := b.Uint8(); err != ErrDestroyed {
+		t.Error("expected ErrDestroyed")
+	}
+}
+
+func TestUint16(t *testing.T) {
+	b, _ := NewImmutable(8)
+	c, _ := NewImmutable(9)
+
+	x, err := b.Uint16()
+	if err != nil {
+		t.Error("unexpected error")
+	}
+	_, err = c.Uint16()
+	if err != ErrInvalidConversion {
+		t.Error("expected ErrInvalidConversion")
+	}
+
+	if unsafe.Pointer(&b.buffer[0]) != unsafe.Pointer(&x[0]) {
+		t.Error("conversion points incorrectly")
+	}
+	if len(x) != 4 || cap(x) != 4 {
+		t.Error("unexpected length or capacity")
+	}
+
+	b.Destroy()
+	c.Destroy()
+
+	if _, err := b.Uint16(); err != ErrDestroyed {
+		t.Error("expected ErrDestroyed")
+	}
+}
+
+func TestUint32(t *testing.T) {
+	b, _ := NewImmutable(8)
+	c, _ := NewImmutable(9)
+
+	x, err := b.Uint32()
+	if err != nil {
+		t.Error("unexpected error")
+	}
+	_, err = c.Uint32()
+	if err != ErrInvalidConversion {
+		t.Error("expected ErrInvalidConversion")
+	}
+
+	if unsafe.Pointer(&b.buffer[0]) != unsafe.Pointer(&x[0]) {
+		t.Error("conversion points incorrectly")
+	}
+	if len(x) != 2 || cap(x) != 2 {
+		t.Error("unexpected length or capacity")
+	}
+
+	b.Destroy()
+	c.Destroy()
+
+	if _, err := b.Uint32(); err != ErrDestroyed {
+		t.Error("expected ErrDestroyed")
+	}
+}
+
+func TestUint64(t *testing.T) {
+	b, _ := NewImmutable(8)
+	c, _ := NewImmutable(9)
+
+	x, err := b.Uint64()
+	if err != nil {
+		t.Error("unexpected error")
+	}
+	_, err = c.Uint64()
+	if err != ErrInvalidConversion {
+		t.Error("expected ErrInvalidConversion")
+	}
+
+	if unsafe.Pointer(&b.buffer[0]) != unsafe.Pointer(&x[0]) {
+		t.Error("conversion points incorrectly")
+	}
+	if len(x) != 1 || cap(x) != 1 {
+		t.Error("unexpected length or capacity")
+	}
+
+	b.Destroy()
+	c.Destroy()
+
+	if _, err := b.Uint64(); err != ErrDestroyed {
+		t.Error("expected ErrDestroyed")
+	}
+}
+
+func TestInt8(t *testing.T) {
+	b, _ := NewImmutable(8)
+	c, _ := NewImmutable(9)
+
+	x, err := b.Int8()
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	if unsafe.Pointer(&b.buffer[0]) != unsafe.Pointer(&x[0]) {
+		t.Error("conversion points incorrectly")
+	}
+	if len(x) != 8 || cap(x) != 8 {
+		t.Error("unexpected length or capacity")
+	}
+
+	b.Destroy()
+	c.Destroy()
+
+	if _, err := b.Int8(); err != ErrDestroyed {
+		t.Error("expected ErrDestroyed")
+	}
+}
+
+func TestInt16(t *testing.T) {
+	b, _ := NewImmutable(8)
+	c, _ := NewImmutable(9)
+
+	x, err := b.Int16()
+	if err != nil {
+		t.Error("unexpected error")
+	}
+	_, err = c.Int16()
+	if err != ErrInvalidConversion {
+		t.Error("expected ErrInvalidConversion")
+	}
+
+	if unsafe.Pointer(&b.buffer[0]) != unsafe.Pointer(&x[0]) {
+		t.Error("conversion points incorrectly")
+	}
+	if len(x) != 4 || cap(x) != 4 {
+		t.Error("unexpected length or capacity")
+	}
+
+	b.Destroy()
+	c.Destroy()
+
+	if _, err := b.Int16(); err != ErrDestroyed {
+		t.Error("expected ErrDestroyed")
+	}
+}
+
+func TestInt32(t *testing.T) {
+	b, _ := NewImmutable(8)
+	c, _ := NewImmutable(9)
+
+	x, err := b.Int32()
+	if err != nil {
+		t.Error("unexpected error")
+	}
+	_, err = c.Int32()
+	if err != ErrInvalidConversion {
+		t.Error("expected ErrInvalidConversion")
+	}
+
+	if unsafe.Pointer(&b.buffer[0]) != unsafe.Pointer(&x[0]) {
+		t.Error("conversion points incorrectly")
+	}
+	if len(x) != 2 || cap(x) != 2 {
+		t.Error("unexpected length or capacity")
+	}
+
+	b.Destroy()
+	c.Destroy()
+
+	if _, err := b.Int32(); err != ErrDestroyed {
+		t.Error("expected ErrDestroyed")
+	}
+}
+
+func TestInt64(t *testing.T) {
+	b, _ := NewImmutable(8)
+	c, _ := NewImmutable(9)
+
+	x, err := b.Int64()
+	if err != nil {
+		t.Error("unexpected error")
+	}
+	_, err = c.Int64()
+	if err != ErrInvalidConversion {
+		t.Error("expected ErrInvalidConversion")
+	}
+
+	if unsafe.Pointer(&b.buffer[0]) != unsafe.Pointer(&x[0]) {
+		t.Error("conversion points incorrectly")
+	}
+	if len(x) != 1 || cap(x) != 1 {
+		t.Error("unexpected length or capacity")
+	}
+
+	b.Destroy()
+	c.Destroy()
+
+	if _, err := b.Int64(); err != ErrDestroyed {
+		t.Error("expected ErrDestroyed")
 	}
 }
 


### PR DESCRIPTION
This release will add support for the following extra representations of a LockedBuffer:

```
func (b *LockedBuffer) Uint8() ([]uint8, error)
func (b *LockedBuffer) Uint16() ([]uint16, error)
func (b *LockedBuffer) Uint32() ([]uint32, error)
func (b *LockedBuffer) Uint64() ([]uint64, error)

func (b *LockedBuffer) Int8() ([]int8, error)
func (b *LockedBuffer) Int16() ([]int16, error)
func (b *LockedBuffer) Int32() ([]int32, error)
func (b *LockedBuffer) Int64() ([]int64, error)
```