### PR TITLE
feature: re-add the wipebytes function

### DIFF
--- a/internals.go
+++ b/internals.go
@@ -93,9 +93,11 @@ func fillRandBytes(b []byte) {
 
 // Wipes a byte slice with zeroes.
 func wipeBytes(buf []byte) {
-	// Iterate over the slice...
-	for i := 0; i < len(buf); i++ {
-		// ... setting each element to zero.
-		buf[i] = byte(0)
+	if len(buf) == 0 {
+		return
+	}
+	buf[0] = 0
+	for bp := 1; bp < len(buf); bp *= 2 {
+		copy(buf[bp:], buf[:bp])
 	}
 }

--- a/memguard.go
+++ b/memguard.go
@@ -804,6 +804,15 @@ func Trim(b *LockedBuffer, offset, size int) (*LockedBuffer, error) {
 }
 
 /*
+WipeBytes zeroes out a given byte slice. It is recommeded that you call WipeBytes on slices after utilizing the Copy or CopyAt methods.
+
+Due to the nature of memory allocated by the Go runtime, WipeBytes cannot guarantee that the data does not exist elsewhere in memory. Therefore, your program should aim to (when possible) store sensitive data only in LockedBuffers.
+*/
+func WipeBytes(b []byte) {
+	wipeBytes(b)
+}
+
+/*
 DestroyAll calls Destroy on all LockedBuffers that have not already been destroyed.
 
 CatchInterrupt and SafeExit both call DestroyAll before exiting.

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -693,6 +693,27 @@ func TestTrim(t *testing.T) {
 	}
 }
 
+func TestWipeBytes(t *testing.T) {
+	// Create random byte slice.
+	b := make([]byte, 32)
+	fillRandBytes(b)
+
+	// Wipe it.
+	WipeBytes(b)
+
+	// Check.
+	if !bytes.Equal(b, make([]byte, 32)) {
+		t.Error("unsuccessful wipe")
+	}
+
+	// Try with empty list.
+	ebuf := make([]byte, 0)
+	WipeBytes(ebuf)
+	if len(ebuf) != 0 || cap(ebuf) != 0 {
+		t.Error("changes made to zero-sized slice")
+	}
+}
+
 func TestCatchInterrupt(t *testing.T) {
 	CatchInterrupt(func() {})
 


### PR DESCRIPTION
Re-add the WipeBytes function in light of the issue raised in #58. Also added a warning about its potential limitations to its documentation.

The implementation has also been improved.

Closes #58.