### PR TITLE
breaking: rename container and buffer method

### DIFF
--- a/container.go
+++ b/container.go
@@ -10,17 +10,17 @@ import (
 )
 
 /*
-LockedBuffer is a structure that holds secure values.
+Enclave is a structure that holds secure values.
 
 The protected memory itself can be accessed with the Buffer() method. The various states can be accessed with the IsDestroyed() and IsMutable() methods, both of which are pretty self-explanatory.
 
-The number of LockedBuffers that you are able to create is limited by how much memory your system kernel allows each process to mlock/VirtualLock. Therefore you should call Destroy on LockedBuffers that you no longer need, or simply defer a Destroy call after creating a new LockedBuffer.
+The number of Enclaves that you are able to create is limited by how much memory your system kernel allows each process to mlock/VirtualLock. Therefore you should call Destroy on Enclaves that you no longer need, or simply defer a Destroy call after creating a new Enclave.
 
-The entire memguard API handles and passes around pointers to LockedBuffers, and so, for both security and convenience, you should refrain from dereferencing a LockedBuffer.
+The entire memguard API handles and passes around pointers to Enclaves, and so, for both security and convenience, you should refrain from dereferencing a Enclave.
 
-If an API function that needs to edit a LockedBuffer is given one that is immutable, the call will return an ErrImmutable. Similarly, if a function is given a LockedBuffer that has been destroyed, the call will return an ErrDestroyed.
+If an API function that needs to edit a Enclave is given one that is immutable, the call will return an ErrImmutable. Similarly, if a function is given a Enclave that has been destroyed, the call will return an ErrDestroyed.
 */
-type LockedBuffer struct {
+type Enclave struct {
 	*container  // Import all the container fields.
 	*littleBird // Monitor this for auto-destruction.
 }
@@ -30,23 +30,23 @@ type container struct {
 	sync.Mutex // Local mutex lock.
 
 	buffer  []byte // Slice that references the protected memory.
-	mutable bool   // Is this LockedBuffer mutable?
+	mutable bool   // Is this Enclave mutable?
 }
 
-// littleBird is a value that we monitor instead of the LockedBuffer
-// itself. It allows us to tell the GC to auto-destroy LockedBuffers.
+// littleBird is a value that we monitor instead of the Enclave
+// itself. It allows us to tell the GC to auto-destroy Enclaves.
 type littleBird [16]byte
 
 // Global internal function used to create new secure containers.
-func newContainer(size int, mutable bool) (*LockedBuffer, error) {
+func newContainer(size int, mutable bool) (*Enclave, error) {
 	// Return an error if length < 1.
 	if size < 1 {
 		return nil, ErrInvalidLength
 	}
 
-	// Allocate a new LockedBuffer.
+	// Allocate a new Enclave.
 	ib := new(container)
-	b := &LockedBuffer{ib, new(littleBird)}
+	b := &Enclave{ib, new(littleBird)}
 
 	// Round length + 32 bytes for the canary to a multiple of the page size..
 	roundedLength := roundToPageSize(size + 32)
@@ -93,12 +93,12 @@ func newContainer(size int, mutable bool) (*LockedBuffer, error) {
 		go ib.Destroy()
 	})
 
-	// Append the container to allLockedBuffers. We have to add container
-	// instead of LockedBuffer so that littleBird can become unreachable.
-	allLockedBuffersMutex.Lock()
-	allLockedBuffers = append(allLockedBuffers, ib)
-	allLockedBuffersMutex.Unlock()
+	// Append the container to allEnclaves. We have to add container
+	// instead of Enclave so that littleBird can become unreachable.
+	allEnclavesMutex.Lock()
+	allEnclaves = append(allEnclaves, ib)
+	allEnclavesMutex.Unlock()
 
-	// Return a pointer to the LockedBuffer.
+	// Return a pointer to the Enclave.
 	return b, nil
 }

--- a/docs.go
+++ b/docs.go
@@ -14,7 +14,7 @@ Package memguard lets you easily handle sensitive values in memory.
         memguard.CatchInterrupt(func() {
             fmt.Println("Interrupt signal received. Exiting...")
         })
-        // Make sure to destroy all LockedBuffers when returning.
+        // Make sure to destroy all Enclaves when returning.
         defer memguard.DestroyAll()
 
         // Normal code continues from here.
@@ -37,7 +37,7 @@ Package memguard lets you easily handle sensitive values in memory.
         fmt.Printf("This key starts with %x\n", key.Buffer()[0])
     }
 
-The number of LockedBuffers that you are able to create is limited by how much memory your system kernel allows each process to mlock/VirtualLock. Therefore you should call Destroy on LockedBuffers that you no longer need, or simply defer a Destroy call after creating a new LockedBuffer.
+The number of Enclaves that you are able to create is limited by how much memory your system kernel allows each process to mlock/VirtualLock. Therefore you should call Destroy on Enclaves that you no longer need, or simply defer a Destroy call after creating a new Enclave.
 
 If a function that you're using requires an array, you can cast the buffer to an array and then pass around a pointer. Make sure that you do not dereference the pointer and pass around the resulting value, as this will leave copies all over the place.
 
@@ -52,7 +52,7 @@ If a function that you're using requires an array, you can cast the buffer to an
     // In this case that size is 16. This is very important.
     keyArrayPtr := (*[16]byte)(unsafe.Pointer(&key.Buffer()[0]))
 
-The MemGuard API is thread-safe. You can extend this thread-safety to outside of the API functions by using the Mutex that each LockedBuffer exposes. Don't use the mutex when calling a function that is part of the MemGuard API though, or the process will deadlock.
+The MemGuard API is thread-safe. You can extend this thread-safety to outside of the API functions by using the Mutex that each Enclave exposes. Don't use the mutex when calling a function that is part of the MemGuard API though, or the process will deadlock.
 
 When terminating your application, care should be taken to securely cleanup everything.
 

--- a/errors.go
+++ b/errors.go
@@ -2,14 +2,14 @@ package memguard
 
 import "errors"
 
-// ErrDestroyed is returned when a function is called on a destroyed LockedBuffer.
+// ErrDestroyed is returned when a function is called on a destroyed Enclave.
 var ErrDestroyed = errors.New("memguard.ErrDestroyed: buffer is destroyed")
 
-// ErrImmutable is returned when a function that needs to modify a LockedBuffer is given a LockedBuffer that is immutable.
+// ErrImmutable is returned when a function that needs to modify a Enclave is given a Enclave that is immutable.
 var ErrImmutable = errors.New("memguard.ErrImmutable: cannot modify immutable buffer")
 
-// ErrInvalidLength is returned when a LockedBuffer of smaller than one byte is requested.
+// ErrInvalidLength is returned when a Enclave of smaller than one byte is requested.
 var ErrInvalidLength = errors.New("memguard.ErrInvalidLength: length of buffer must be greater than zero")
 
-// ErrInvalidConversion is returned when attempting to get a slice of a LockedBuffer that is of an inappropriate size for that slice type. For example, attempting to get a []uint16 representation of a LockedBuffer of length 9 bytes would trigger this error, since there would be a byte leftover after the conversion.
+// ErrInvalidConversion is returned when attempting to get a slice of a Enclave that is of an inappropriate size for that slice type. For example, attempting to get a []uint16 representation of a Enclave of length 9 bytes would trigger this error, since there would be a byte leftover after the conversion.
 var ErrInvalidConversion = errors.New("memguard.ErrInvalidConversion: length of buffer must align with target type")

--- a/internals.go
+++ b/internals.go
@@ -20,8 +20,8 @@ var (
 	catchInterruptOnce sync.Once
 
 	// Array of all active containers, and associated mutex.
-	allLockedBuffers      []*container
-	allLockedBuffersMutex = &sync.Mutex{}
+	allEnclaves      []*container
+	allEnclavesMutex = &sync.Mutex{}
 )
 
 // Create and allocate a canary value. Return to caller.
@@ -69,7 +69,7 @@ func roundToPageSize(length int) int {
 	return (length + (pageSize - 1)) & (^(pageSize - 1))
 }
 
-// Get a slice that describes all memory related to a LockedBuffer.
+// Get a slice that describes all memory related to a Enclave.
 func getAllMemory(b *container) []byte {
 	// Calculate the size of the entire container's memory.
 	roundedBufLen := roundToPageSize(len(b.buffer) + 32)

--- a/memguard.go
+++ b/memguard.go
@@ -12,34 +12,34 @@ import (
 )
 
 /*
-NewImmutable creates a new, immutable LockedBuffer of a specified size.
+NewImmutable creates a new, immutable Enclave of a specified size.
 
 The mutability can later be toggled with the MakeImmutable and MakeMutable methods.
 
 If the given length is less than one, the call will return an ErrInvalidLength.
 */
-func NewImmutable(size int) (*LockedBuffer, error) {
+func NewImmutable(size int) (*Enclave, error) {
 	return newContainer(size, false)
 }
 
 /*
-NewMutable creates a new, mutable LockedBuffer of a specified length.
+NewMutable creates a new, mutable Enclave of a specified length.
 
 The mutability can later be toggled with the MakeImmutable and MakeMutable methods.
 
 If the given length is less than one, the call will return an ErrInvalidLength.
 */
-func NewMutable(size int) (*LockedBuffer, error) {
+func NewMutable(size int) (*Enclave, error) {
 	return newContainer(size, true)
 }
 
 /*
-NewImmutableFromBytes is identical to NewImmutable but for the fact that the created LockedBuffer is of the same length and has the same contents as a given slice. The slice is wiped after the bytes have been copied over.
+NewImmutableFromBytes is identical to NewImmutable but for the fact that the created Enclave is of the same length and has the same contents as a given slice. The slice is wiped after the bytes have been copied over.
 
 If the size of the slice is zero, the call will return an ErrInvalidLength.
 */
-func NewImmutableFromBytes(buf []byte) (*LockedBuffer, error) {
-	// Create a new LockedBuffer.
+func NewImmutableFromBytes(buf []byte) (*Enclave, error) {
+	// Create a new Enclave.
 	b, err := NewMutableFromBytes(buf)
 	if err != nil {
 		return nil, err
@@ -48,17 +48,17 @@ func NewImmutableFromBytes(buf []byte) (*LockedBuffer, error) {
 	// Mark as immutable.
 	b.MakeImmutable()
 
-	// Return a pointer to the LockedBuffer.
+	// Return a pointer to the Enclave.
 	return b, nil
 }
 
 /*
-NewMutableFromBytes is identical to NewMutable but for the fact that the created LockedBuffer is of the same length and has the same contents as a given slice. The slice is wiped after the bytes have been copied over.
+NewMutableFromBytes is identical to NewMutable but for the fact that the created Enclave is of the same length and has the same contents as a given slice. The slice is wiped after the bytes have been copied over.
 
 If the size of the slice is zero, the call will return an ErrInvalidLength.
 */
-func NewMutableFromBytes(buf []byte) (*LockedBuffer, error) {
-	// Create a new LockedBuffer.
+func NewMutableFromBytes(buf []byte) (*Enclave, error) {
+	// Create a new Enclave.
 	b, err := newContainer(len(buf), true)
 	if err != nil {
 		return nil, err
@@ -67,15 +67,15 @@ func NewMutableFromBytes(buf []byte) (*LockedBuffer, error) {
 	// Copy the bytes from buf, wiping afterwards.
 	b.Move(buf)
 
-	// Return a pointer to the LockedBuffer.
+	// Return a pointer to the Enclave.
 	return b, nil
 }
 
 /*
-NewImmutableRandom is identical to NewImmutable but for the fact that the created LockedBuffer is filled with cryptographically-secure pseudo-random bytes instead of zeroes. Therefore a LockedBuffer created with NewImmutableRandom can safely be used as an encryption key.
+NewImmutableRandom is identical to NewImmutable but for the fact that the created Enclave is filled with cryptographically-secure pseudo-random bytes instead of zeroes. Therefore a Enclave created with NewImmutableRandom can safely be used as an encryption key.
 */
-func NewImmutableRandom(size int) (*LockedBuffer, error) {
-	// Create a new LockedBuffer for the key.
+func NewImmutableRandom(size int) (*Enclave, error) {
+	// Create a new Enclave for the key.
 	b, err := NewMutableRandom(size)
 	if err != nil {
 		return nil, err
@@ -84,15 +84,15 @@ func NewImmutableRandom(size int) (*LockedBuffer, error) {
 	// Mark as immutable if specified.
 	b.MakeImmutable()
 
-	// Return the LockedBuffer.
+	// Return the Enclave.
 	return b, nil
 }
 
 /*
-NewMutableRandom is identical to NewMutable but for the fact that the created LockedBuffer is filled with cryptographically-secure pseudo-random bytes instead of zeroes. Therefore a LockedBuffer created with NewMutableRandom can safely be used as an encryption key.
+NewMutableRandom is identical to NewMutable but for the fact that the created Enclave is filled with cryptographically-secure pseudo-random bytes instead of zeroes. Therefore a Enclave created with NewMutableRandom can safely be used as an encryption key.
 */
-func NewMutableRandom(size int) (*LockedBuffer, error) {
-	// Create a new LockedBuffer for the key.
+func NewMutableRandom(size int) (*Enclave, error) {
+	// Create a new Enclave for the key.
 	b, err := newContainer(size, true)
 	if err != nil {
 		return nil, err
@@ -101,24 +101,24 @@ func NewMutableRandom(size int) (*LockedBuffer, error) {
 	// Fill it with random data.
 	fillRandBytes(b.buffer)
 
-	// Return the LockedBuffer.
+	// Return the Enclave.
 	return b, nil
 }
 
 /*
-Buffer returns a slice that references the secure, protected portion of memory.
+Bytes returns a slice that references the secure, protected portion of memory.
 
-If the LockedBuffer that you call Buffer on has been destroyed, the returned slice will be nil (it will have a length and capacity of zero).
+If the Enclave that you call Bytes on has been destroyed, the returned slice will be nil (it will have a length and capacity of zero).
 
-If a function that you're using requires an array, you can cast the buffer to an array and then pass around a pointer:
+If a function that you're using requires an array, you can cast the slice to an array and then pass around a pointer:
 
     // Make sure the size of the array matches the size of the buffer.
     // In this case that size is 16. This is *very* important.
-    keyArrayPtr := (*[16]byte)(unsafe.Pointer(&b.Buffer()[0]))
+    keyArrayPtr := (*[16]byte)(unsafe.Pointer(&b.Bytes()[0]))
 
 Make sure that you do not dereference the pointer and pass around the resulting value, as this will leave copies all over the place.
 */
-func (b *container) Buffer() []byte {
+func (b *container) Bytes() []byte {
 	return b.buffer
 }
 
@@ -144,7 +144,7 @@ func (b *container) Uint8() ([]uint8, error) {
 /*
 Uint16 returns a slice (of type []uint16) that references the secure, protected portion of memory.
 
-The LockedBuffer must be a multiple of 2 bytes in length, or else an error will be returned.
+The Enclave must be a multiple of 2 bytes in length, or else an error will be returned.
 */
 func (b *container) Uint16() ([]uint16, error) {
 	// Attain the mutex lock.
@@ -175,7 +175,7 @@ func (b *container) Uint16() ([]uint16, error) {
 /*
 Uint32 returns a slice (of type []uint32) that references the secure, protected portion of memory.
 
-The LockedBuffer must be a multiple of 4 bytes in length, or else an error will be returned.
+The Enclave must be a multiple of 4 bytes in length, or else an error will be returned.
 */
 func (b *container) Uint32() ([]uint32, error) {
 	// Attain the mutex lock.
@@ -206,7 +206,7 @@ func (b *container) Uint32() ([]uint32, error) {
 /*
 Uint64 returns a slice (of type []uint64) that references the secure, protected portion of memory.
 
-The LockedBuffer must be a multiple of 8 bytes in length, or else an error will be returned.
+The Enclave must be a multiple of 8 bytes in length, or else an error will be returned.
 */
 func (b *container) Uint64() ([]uint64, error) {
 	// Attain the mutex lock.
@@ -261,7 +261,7 @@ func (b *container) Int8() ([]int8, error) {
 /*
 Int16 returns a slice (of type []int16) that references the secure, protected portion of memory.
 
-The LockedBuffer must be a multiple of 2 bytes in length, or else an error will be returned.
+The Enclave must be a multiple of 2 bytes in length, or else an error will be returned.
 */
 func (b *container) Int16() ([]int16, error) {
 	// Attain the mutex lock.
@@ -292,7 +292,7 @@ func (b *container) Int16() ([]int16, error) {
 /*
 Int32 returns a slice (of type []int32) that references the secure, protected portion of memory.
 
-The LockedBuffer must be a multiple of 4 bytes in length, or else an error will be returned.
+The Enclave must be a multiple of 4 bytes in length, or else an error will be returned.
 */
 func (b *container) Int32() ([]int32, error) {
 	// Attain the mutex lock.
@@ -323,7 +323,7 @@ func (b *container) Int32() ([]int32, error) {
 /*
 Int64 returns a slice (of type []int64) that references the secure, protected portion of memory.
 
-The LockedBuffer must be a multiple of 8 bytes in length, or else an error will be returned.
+The Enclave must be a multiple of 8 bytes in length, or else an error will be returned.
 */
 func (b *container) Int64() ([]int64, error) {
 	// Attain the mutex lock.
@@ -352,10 +352,10 @@ func (b *container) Int64() ([]int64, error) {
 }
 
 /*
-IsMutable returns a boolean value indicating if a LockedBuffer is marked read-only.
+IsMutable returns a boolean value indicating if a Enclave is marked read-only.
 */
 func (b *container) IsMutable() bool {
-	// Get a mutex lock on this LockedBuffer.
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -363,10 +363,10 @@ func (b *container) IsMutable() bool {
 }
 
 /*
-IsDestroyed returns a boolean value indicating if a LockedBuffer has been destroyed.
+IsDestroyed returns a boolean value indicating if a Enclave has been destroyed.
 */
 func (b *container) IsDestroyed() bool {
-	// Get a mutex lock on this LockedBuffer.
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -375,10 +375,10 @@ func (b *container) IsDestroyed() bool {
 }
 
 /*
-EqualBytes compares a LockedBuffer to a byte slice in constant time.
+EqualBytes compares a Enclave to a byte slice in constant time.
 */
 func (b *container) EqualBytes(buf []byte) (bool, error) {
-	// Get a mutex lock on this LockedBuffer.
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -398,12 +398,12 @@ func (b *container) EqualBytes(buf []byte) (bool, error) {
 }
 
 /*
-MakeImmutable asks the kernel to mark the LockedBuffer's memory as immutable. Any subsequent attempts to modify this memory will result in the process crashing with a SIGSEGV memory violation.
+MakeImmutable asks the kernel to mark the Enclave's memory as immutable. Any subsequent attempts to modify this memory will result in the process crashing with a SIGSEGV memory violation.
 
 To make the memory mutable again, MakeMutable is called.
 */
 func (b *container) MakeImmutable() error {
-	// Get a mutex lock on this LockedBuffer.
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -427,12 +427,12 @@ func (b *container) MakeImmutable() error {
 }
 
 /*
-MakeMutable asks the kernel to mark the LockedBuffer's memory as mutable.
+MakeMutable asks the kernel to mark the Enclave's memory as mutable.
 
 To make the memory immutable again, MakeImmutable is called.
 */
 func (b *container) MakeMutable() error {
-	// Get a mutex lock on this LockedBuffer.
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -456,13 +456,13 @@ func (b *container) MakeMutable() error {
 }
 
 /*
-Copy copies bytes from a byte slice into a LockedBuffer in constant-time. Just like Golang's built-in copy function, Copy only copies up to the smallest of the two buffers.
+Copy copies bytes from a byte slice into a Enclave in constant-time. Just like Golang's built-in copy function, Copy only copies up to the smallest of the two buffers.
 
 It does not wipe the original slice so using Copy is less secure than using Move. Therefore Move should be favoured unless you have a good reason.
 
 You should aim to call WipeBytes on the original slice as soon as possible.
 
-If the LockedBuffer is marked as read-only, the call will fail and return an ErrReadOnly.
+If the Enclave is marked as read-only, the call will fail and return an ErrReadOnly.
 */
 func (b *container) Copy(buf []byte) error {
 	// Just call CopyAt with a zero offset.
@@ -470,10 +470,10 @@ func (b *container) Copy(buf []byte) error {
 }
 
 /*
-CopyAt is identical to Copy but it copies into the LockedBuffer at a specified offset.
+CopyAt is identical to Copy but it copies into the Enclave at a specified offset.
 */
 func (b *container) CopyAt(buf []byte, offset int) error {
-	// Get a mutex lock on this LockedBuffer.
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -500,11 +500,11 @@ func (b *container) CopyAt(buf []byte, offset int) error {
 }
 
 /*
-Move moves bytes from a byte slice into a LockedBuffer in constant-time. Just like Golang's built-in copy function, Move only moves up to the smallest of the two buffers.
+Move moves bytes from a byte slice into a Enclave in constant-time. Just like Golang's built-in copy function, Move only moves up to the smallest of the two buffers.
 
 Unlike Copy, Move wipes the entire original slice after copying the appropriate number of bytes over, and so it should be favoured unless you have a good reason.
 
-If the LockedBuffer is marked as read-only, the call will fail and return an ErrReadOnly.
+If the Enclave is marked as read-only, the call will fail and return an ErrReadOnly.
 */
 func (b *container) Move(buf []byte) error {
 	// Just call MoveAt with a zero offset.
@@ -512,10 +512,10 @@ func (b *container) Move(buf []byte) error {
 }
 
 /*
-MoveAt is identical to Move but it copies into the LockedBuffer at a specified offset.
+MoveAt is identical to Move but it copies into the Enclave at a specified offset.
 */
 func (b *container) MoveAt(buf []byte, offset int) error {
-	// Copy buf into the LockedBuffer.
+	// Copy buf into the Enclave.
 	if err := b.CopyAt(buf, offset); err != nil {
 		return err
 	}
@@ -528,7 +528,7 @@ func (b *container) MoveAt(buf []byte, offset int) error {
 }
 
 /*
-FillRandomBytes fills a LockedBuffer with cryptographically-secure pseudo-random bytes.
+FillRandomBytes fills a Enclave with cryptographically-secure pseudo-random bytes.
 */
 func (b *container) FillRandomBytes() error {
 	// Just call FillRandomBytesAt.
@@ -536,10 +536,10 @@ func (b *container) FillRandomBytes() error {
 }
 
 /*
-FillRandomBytesAt fills a LockedBuffer with cryptographically-secure pseudo-random bytes, starting at an offset and ending after a given number of bytes.
+FillRandomBytesAt fills a Enclave with cryptographically-secure pseudo-random bytes, starting at an offset and ending after a given number of bytes.
 */
 func (b *container) FillRandomBytesAt(offset, length int) error {
-	// Get a mutex lock on this LockedBuffer.
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -563,12 +563,12 @@ func (b *container) FillRandomBytesAt(offset, length int) error {
 /*
 Destroy verifies that no buffer underflows occurred and then wipes, unlocks, and frees all related memory. If a buffer underflow is detected, the process panics.
 
-This function must be called on all LockedBuffers before exiting. DestroyAll is designed for this purpose, as is CatchInterrupt and SafeExit. We recommend using all of them together.
+This function must be called on all Enclaves before exiting. DestroyAll is designed for this purpose, as is CatchInterrupt and SafeExit. We recommend using all of them together.
 
-If the LockedBuffer has already been destroyed then the call makes no changes.
+If the Enclave has already been destroyed then the call makes no changes.
 */
 func (b *container) Destroy() {
-	// Attain a mutex lock on this LockedBuffer.
+	// Attain a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -578,16 +578,16 @@ func (b *container) Destroy() {
 	}
 
 	// Remove this one from global slice.
-	allLockedBuffersMutex.Lock()
-	for i, v := range allLockedBuffers {
+	allEnclavesMutex.Lock()
+	for i, v := range allEnclaves {
 		if v == b {
-			allLockedBuffers = append(allLockedBuffers[:i], allLockedBuffers[i+1:]...)
+			allEnclaves = append(allEnclaves[:i], allEnclaves[i+1:]...)
 			break
 		}
 	}
-	allLockedBuffersMutex.Unlock()
+	allEnclavesMutex.Unlock()
 
-	// Get all of the memory related to this LockedBuffer.
+	// Get all of the memory related to this Enclave.
 	memory := getAllMemory(b)
 
 	// Get the total size of all the pages between the guards.
@@ -624,19 +624,19 @@ func (b *container) Destroy() {
 }
 
 /*
-Size returns an integer representing the total length, in bytes, of a LockedBuffer.
+Size returns an integer representing the total length, in bytes, of a Enclave.
 
-If this size is zero, it is safe to assume that the LockedBuffer has been destroyed.
+If this size is zero, it is safe to assume that the Enclave has been destroyed.
 */
 func (b *container) Size() int {
 	return len(b.buffer)
 }
 
 /*
-Wipe wipes a LockedBuffer's contents by overwriting the buffer with zeroes.
+Wipe wipes a Enclave's contents by overwriting the buffer with zeroes.
 */
 func (b *container) Wipe() error {
-	// Get a mutex lock on this LockedBuffer.
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -658,12 +658,12 @@ func (b *container) Wipe() error {
 }
 
 /*
-Concatenate takes two LockedBuffers and concatenates them.
+Concatenate takes two Enclaves and concatenates them.
 
-If one of the given LockedBuffers is immutable, the resulting LockedBuffer will also be immutable. The original LockedBuffers are not destroyed.
+If one of the given Enclaves is immutable, the resulting Enclave will also be immutable. The original Enclaves are not destroyed.
 */
-func Concatenate(a, b *LockedBuffer) (*LockedBuffer, error) {
-	// Get a mutex lock on the LockedBuffers.
+func Concatenate(a, b *Enclave) (*Enclave, error) {
+	// Get a mutex lock on the Enclaves.
 	a.Lock()
 	b.Lock()
 	defer a.Unlock()
@@ -674,7 +674,7 @@ func Concatenate(a, b *LockedBuffer) (*LockedBuffer, error) {
 		return nil, ErrDestroyed
 	}
 
-	// Create a new LockedBuffer to hold the concatenated value.
+	// Create a new Enclave to hold the concatenated value.
 	c, _ := NewMutable(len(a.buffer) + len(b.buffer))
 
 	// Copy the values across.
@@ -686,15 +686,15 @@ func Concatenate(a, b *LockedBuffer) (*LockedBuffer, error) {
 		c.MakeImmutable()
 	}
 
-	// Return the resulting LockedBuffer.
+	// Return the resulting Enclave.
 	return c, nil
 }
 
 /*
-Duplicate takes a LockedBuffer and creates a new one with the same contents and mutability state as the original.
+Duplicate takes a Enclave and creates a new one with the same contents and mutability state as the original.
 */
-func Duplicate(b *LockedBuffer) (*LockedBuffer, error) {
-	// Get a mutex lock on this LockedBuffer.
+func Duplicate(b *Enclave) (*Enclave, error) {
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -703,7 +703,7 @@ func Duplicate(b *LockedBuffer) (*LockedBuffer, error) {
 		return nil, ErrDestroyed
 	}
 
-	// Create new LockedBuffer.
+	// Create new Enclave.
 	newBuf, _ := NewMutable(b.Size())
 
 	// Copy bytes into it.
@@ -719,10 +719,10 @@ func Duplicate(b *LockedBuffer) (*LockedBuffer, error) {
 }
 
 /*
-Equal compares the contents of two LockedBuffers in constant time.
+Equal compares the contents of two Enclaves in constant time.
 */
-func Equal(a, b *LockedBuffer) (bool, error) {
-	// Get a mutex lock on the LockedBuffers.
+func Equal(a, b *Enclave) (bool, error) {
+	// Get a mutex lock on the Enclaves.
 	a.Lock()
 	b.Lock()
 	defer a.Unlock()
@@ -744,10 +744,10 @@ func Equal(a, b *LockedBuffer) (bool, error) {
 }
 
 /*
-Split takes a LockedBuffer, splits it at a specified offset, and then returns the two newly created LockedBuffers. The mutability state of the original is preserved in the new LockedBuffers, and the original LockedBuffer is not destroyed.
+Split takes a Enclave, splits it at a specified offset, and then returns the two newly created Enclaves. The mutability state of the original is preserved in the new Enclaves, and the original Enclave is not destroyed.
 */
-func Split(b *LockedBuffer, offset int) (*LockedBuffer, *LockedBuffer, error) {
-	// Get a mutex lock on this LockedBuffer.
+func Split(b *Enclave, offset int) (*Enclave, *Enclave, error) {
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -756,7 +756,7 @@ func Split(b *LockedBuffer, offset int) (*LockedBuffer, *LockedBuffer, error) {
 		return nil, nil, ErrDestroyed
 	}
 
-	// Create two new LockedBuffers.
+	// Create two new Enclaves.
 	firstBuf, err := NewMutable(len(b.buffer[:offset]))
 	if err != nil {
 		return nil, nil, err
@@ -778,17 +778,17 @@ func Split(b *LockedBuffer, offset int) (*LockedBuffer, *LockedBuffer, error) {
 		secondBuf.MakeImmutable()
 	}
 
-	// Return the new LockedBuffers.
+	// Return the new Enclaves.
 	return firstBuf, secondBuf, nil
 }
 
 /*
-Trim shortens a LockedBuffer according to the given specifications. The mutability state of the original is preserved in the new LockedBuffer, and the original LockedBuffer is not destroyed.
+Trim shortens a Enclave according to the given specifications. The mutability state of the original is preserved in the new Enclave, and the original Enclave is not destroyed.
 
-Trim takes an offset and a size as arguments. The resulting LockedBuffer starts at index [offset] and ends at index [offset+size].
+Trim takes an offset and a size as arguments. The resulting Enclave starts at index [offset] and ends at index [offset+size].
 */
-func Trim(b *LockedBuffer, offset, size int) (*LockedBuffer, error) {
-	// Get a mutex lock on this LockedBuffer.
+func Trim(b *Enclave, offset, size int) (*Enclave, error) {
+	// Get a mutex lock on this Enclave.
 	b.Lock()
 	defer b.Unlock()
 
@@ -797,7 +797,7 @@ func Trim(b *LockedBuffer, offset, size int) (*LockedBuffer, error) {
 		return nil, ErrDestroyed
 	}
 
-	// Create new LockedBuffer and copy over the old.
+	// Create new Enclave and copy over the old.
 	newBuf, err := NewMutable(size)
 	if err != nil {
 		return nil, err
@@ -809,30 +809,30 @@ func Trim(b *LockedBuffer, offset, size int) (*LockedBuffer, error) {
 		newBuf.MakeImmutable()
 	}
 
-	// Return the new LockedBuffer.
+	// Return the new Enclave.
 	return newBuf, nil
 }
 
 /*
 WipeBytes zeroes out a given byte slice. It is recommended that you call WipeBytes on slices after utilizing the Copy or CopyAt methods.
 
-Due to the nature of memory allocated by the Go runtime, WipeBytes cannot guarantee that the data does not exist elsewhere in memory. Therefore, your program should aim to (when possible) store sensitive data only in LockedBuffers.
+Due to the nature of memory allocated by the Go runtime, WipeBytes cannot guarantee that the data does not exist elsewhere in memory. Therefore, your program should aim to (when possible) store sensitive data only in Enclaves.
 */
 func WipeBytes(b []byte) {
 	wipeBytes(b)
 }
 
 /*
-DestroyAll calls Destroy on all LockedBuffers that have not already been destroyed.
+DestroyAll calls Destroy on all Enclaves that have not already been destroyed.
 
 CatchInterrupt and SafeExit both call DestroyAll before exiting.
 */
 func DestroyAll() {
-	// Get a Mutex lock on allLockedBuffers, and get a copy.
-	allLockedBuffersMutex.Lock()
-	containers := make([]*container, len(allLockedBuffers))
-	copy(containers, allLockedBuffers)
-	allLockedBuffersMutex.Unlock()
+	// Get a Mutex lock on allEnclaves, and get a copy.
+	allEnclavesMutex.Lock()
+	containers := make([]*container, len(allEnclaves))
+	copy(containers, allEnclaves)
+	allEnclavesMutex.Unlock()
 
 	for _, b := range containers {
 		b.Destroy()
@@ -867,11 +867,11 @@ SafePanic is identical to Go's panic except it wipes all it can before panicking
 */
 func SafePanic(v interface{}) {
 	// Get a Mutex lock on the global list of buffers. Don't release it.
-	allLockedBuffersMutex.Lock()
+	allEnclavesMutex.Lock()
 
 	// Grab a copy of the list.
-	containers := make([]*container, len(allLockedBuffers))
-	copy(containers, allLockedBuffers)
+	containers := make([]*container, len(allEnclaves))
+	copy(containers, allEnclaves)
 
 	// Wipe them all.
 	for _, b := range containers {

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -13,8 +13,8 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error")
 	}
-	if len(b.Buffer()) != 8 || cap(b.Buffer()) != 8 {
-		t.Error("length or capacity != required; len, cap =", len(b.Buffer()), cap(b.Buffer()))
+	if len(b.Bytes()) != 8 || cap(b.Bytes()) != 8 {
+		t.Error("length or capacity != required; len, cap =", len(b.Bytes()), cap(b.Bytes()))
 	}
 	if b.IsMutable() {
 		t.Error("unexpected state")
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 		t.Error("expected err; got nil")
 	}
 	if c != nil {
-		t.Error("expected nil, got *LockedBuffer")
+		t.Error("expected nil, got *Enclave")
 	}
 
 	a, err := NewMutable(8)
@@ -44,8 +44,8 @@ func TestNewFromBytes(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error")
 	}
-	if !bytes.Equal(b.Buffer(), []byte("test")) {
-		t.Error("b.Buffer() != required")
+	if !bytes.Equal(b.Bytes(), []byte("test")) {
+		t.Error("b.Bytes() != required")
 	}
 	if b.IsMutable() {
 		t.Error("unexpected state")
@@ -57,7 +57,7 @@ func TestNewFromBytes(t *testing.T) {
 		t.Error("expected err; got nil")
 	}
 	if c != nil {
-		t.Error("expected nil, got *LockedBuffer")
+		t.Error("expected nil, got *Enclave")
 	}
 
 	a, err := NewMutableFromBytes([]byte("test"))
@@ -72,7 +72,7 @@ func TestNewFromBytes(t *testing.T) {
 
 func TestNewRandom(t *testing.T) {
 	b, _ := NewImmutableRandom(32)
-	if bytes.Equal(b.Buffer(), make([]byte, 32)) {
+	if bytes.Equal(b.Bytes(), make([]byte, 32)) {
 		t.Error("was not filled with random data")
 	}
 	if b.IsMutable() {
@@ -86,7 +86,7 @@ func TestNewRandom(t *testing.T) {
 		t.Error("expected ErrInvalidLength")
 	}
 	if c != nil {
-		t.Error("expected nil, got *LockedBuffer")
+		t.Error("expected nil, got *Enclave")
 	}
 
 	a, err := NewMutableRandom(8)
@@ -102,13 +102,13 @@ func TestNewRandom(t *testing.T) {
 func TestBuffer(t *testing.T) {
 	b, _ := NewImmutableRandom(8)
 
-	if !bytes.Equal(b.buffer, b.Buffer()) {
+	if !bytes.Equal(b.buffer, b.Bytes()) {
 		t.Error("buffers inequal")
 	}
 
 	b.Destroy()
 
-	if len(b.Buffer()) != 0 || cap(b.Buffer()) != 0 {
+	if len(b.Bytes()) != 0 || cap(b.Bytes()) != 0 {
 		t.Error("expected zero length")
 	}
 }
@@ -375,7 +375,7 @@ func TestEqualTo(t *testing.T) {
 	a.Destroy()
 
 	if equal, err := a.EqualBytes([]byte("test")); equal || err != ErrDestroyed {
-		t.Error("unexpected return values with destroyed LockedBuffer")
+		t.Error("unexpected return values with destroyed Enclave")
 	}
 }
 
@@ -407,41 +407,41 @@ func TestReadOnly(t *testing.T) {
 }
 
 func TestMove(t *testing.T) {
-	// When buf is larger than LockedBuffer.
+	// When buf is larger than Enclave.
 	b, _ := NewMutable(16)
 	buf := []byte("this is a very large buffer")
 	b.Move(buf)
 	if !bytes.Equal(buf, make([]byte, len(buf))) {
 		t.Error("expected buf to be nil")
 	}
-	if !bytes.Equal(b.Buffer(), []byte("this is a very l")) {
+	if !bytes.Equal(b.Bytes(), []byte("this is a very l")) {
 		t.Error("bytes were't copied properly")
 	}
 	b.Destroy()
 
-	// When buf is smaller than LockedBuffer.
+	// When buf is smaller than Enclave.
 	b, _ = NewMutable(16)
 	buf = []byte("diz small buf")
 	b.Move(buf)
 	if !bytes.Equal(buf, make([]byte, len(buf))) {
 		t.Error("expected buf to be nil")
 	}
-	if !bytes.Equal(b.Buffer()[:len(buf)], []byte("diz small buf")) {
+	if !bytes.Equal(b.Bytes()[:len(buf)], []byte("diz small buf")) {
 		t.Error("bytes weren't copied properly")
 	}
-	if !bytes.Equal(b.Buffer()[len(buf):], make([]byte, 16-len(buf))) {
-		t.Error("bytes were't copied properly;", b.Buffer()[len(buf):])
+	if !bytes.Equal(b.Bytes()[len(buf):], make([]byte, 16-len(buf))) {
+		t.Error("bytes were't copied properly;", b.Bytes()[len(buf):])
 	}
 	b.Destroy()
 
-	// When buf is equal in size to LockedBuffer.
+	// When buf is equal in size to Enclave.
 	b, _ = NewMutable(16)
 	buf = []byte("yellow submarine")
 	b.Move(buf)
 	if !bytes.Equal(buf, make([]byte, len(buf))) {
 		t.Error("expected buf to be nil")
 	}
-	if !bytes.Equal(b.Buffer(), []byte("yellow submarine")) {
+	if !bytes.Equal(b.Bytes(), []byte("yellow submarine")) {
 		t.Error("bytes were't copied properly")
 	}
 
@@ -463,15 +463,15 @@ func TestFillRandomBytes(t *testing.T) {
 	a, _ := NewMutable(32)
 	a.FillRandomBytes()
 
-	if bytes.Equal(a.Buffer(), make([]byte, 32)) {
+	if bytes.Equal(a.Bytes(), make([]byte, 32)) {
 		t.Error("not random")
 	}
 
 	a.Wipe()
 	a.FillRandomBytesAt(16, 16)
 
-	if !bytes.Equal(a.Buffer()[:16], make([]byte, 16)) || bytes.Equal(a.Buffer()[16:], make([]byte, 16)) {
-		t.Error("incorrect offset/size;", a.Buffer()[:16], a.Buffer()[16:])
+	if !bytes.Equal(a.Bytes()[:16], make([]byte, 16)) || bytes.Equal(a.Bytes()[16:], make([]byte, 16)) {
+		t.Error("incorrect offset/size;", a.Bytes()[:16], a.Bytes()[16:])
 	}
 
 	a.MakeImmutable()
@@ -494,7 +494,7 @@ func TestDestroyAll(t *testing.T) {
 
 	DestroyAll()
 
-	if b.Buffer() != nil || c.Buffer() != nil {
+	if b.Bytes() != nil || c.Bytes() != nil {
 		t.Error("expected buffers to be nil")
 	}
 
@@ -528,8 +528,8 @@ func TestWipe(t *testing.T) {
 		t.Error("failed to wipe:", err)
 	}
 
-	if !bytes.Equal(b.Buffer(), make([]byte, 16)) {
-		t.Error("bytes not wiped; b =", b.Buffer())
+	if !bytes.Equal(b.Bytes(), make([]byte, 16)) {
+		t.Error("bytes not wiped; b =", b.Bytes())
 	}
 
 	b.FillRandomBytes()
@@ -539,7 +539,7 @@ func TestWipe(t *testing.T) {
 		t.Error("expected ErrImmutable")
 	}
 
-	if bytes.Equal(b.Buffer(), make([]byte, 16)) {
+	if bytes.Equal(b.Bytes(), make([]byte, 16)) {
 		t.Error("bytes wiped")
 	}
 
@@ -561,8 +561,8 @@ func TestConcatenate(t *testing.T) {
 		t.Error("unexpected error")
 	}
 
-	if !bytes.Equal(c.Buffer(), []byte("xxxxyyyy")) {
-		t.Error("unexpected output;", c.Buffer())
+	if !bytes.Equal(c.Bytes(), []byte("xxxxyyyy")) {
+		t.Error("unexpected output;", c.Bytes())
 	}
 	if c.IsMutable() {
 		t.Error("expected immutability")
@@ -584,7 +584,7 @@ func TestDuplicate(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error")
 	}
-	if !bytes.Equal(b.Buffer(), c.Buffer()) {
+	if !bytes.Equal(b.Bytes(), c.Bytes()) {
 		t.Error("duplicated buffer has different contents")
 	}
 	if c.IsMutable() {
@@ -635,16 +635,16 @@ func TestSplit(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error")
 	}
-	if !bytes.Equal(b.Buffer(), []byte("xxxx")) {
+	if !bytes.Equal(b.Bytes(), []byte("xxxx")) {
 		t.Error("first buffer has unexpected value")
 	}
-	if !bytes.Equal(c.Buffer(), []byte("yyyy")) {
+	if !bytes.Equal(c.Bytes(), []byte("yyyy")) {
 		t.Error("second buffer has unexpected value")
 	}
 	if b.IsMutable() || c.IsMutable() {
 		t.Error("permissions not preserved")
 	}
-	if !bytes.Equal(a.Buffer(), []byte("xxxxyyyy")) {
+	if !bytes.Equal(a.Bytes(), []byte("xxxxyyyy")) {
 		t.Error("original is not preserved")
 	}
 
@@ -673,8 +673,8 @@ func TestTrim(t *testing.T) {
 		t.Error("unexpected error")
 	}
 
-	if !bytes.Equal(c.Buffer(), []byte("xxyy")) {
-		t.Error("unexpected value:", c.Buffer())
+	if !bytes.Equal(c.Bytes(), []byte("xxyy")) {
+		t.Error("unexpected value:", c.Bytes())
 	}
 
 	if c.IsMutable() {


### PR DESCRIPTION
* Rename `LockedBuffer` to `Enclave`.
* Rename the container `Buffer` method to `Bytes`.