### PR TITLE
Methods to return arrays of common sizes. Support for setting !EACCES

### DIFF
--- a/container.go
+++ b/container.go
@@ -29,8 +29,9 @@ type LockedBuffer struct {
 type container struct {
 	sync.Mutex // Local mutex lock.
 
-	buffer  []byte // Slice that references the protected memory.
-	mutable bool   // Is this LockedBuffer mutable?
+	buffer   []byte // Slice that references the protected memory.
+	mutable  bool   // Is this LockedBuffer mutable?
+	readable bool   // Is this LockedBuffer readable?
 }
 
 // littleBird is a value that we monitor instead of the LockedBuffer
@@ -78,6 +79,9 @@ func newContainer(size int, mutable bool) (*LockedBuffer, error) {
 	if !mutable {
 		b.MakeImmutable()
 	}
+
+	// Set appropriate readability state.
+	b.readable = true
 
 	// Use a finalizer to make sure the buffer gets destroyed if forgotten.
 	runtime.SetFinalizer(b.littleBird, func(_ *littleBird) {

--- a/docs.go
+++ b/docs.go
@@ -6,7 +6,7 @@ Package memguard lets you easily handle sensitive values in memory.
     import (
         "fmt"
 
-        "github.com/JonathanLogan/memguard"
+        "github.com/awnumar/memguard"
     )
 
     func main() {

--- a/docs.go
+++ b/docs.go
@@ -6,7 +6,7 @@ Package memguard lets you easily handle sensitive values in memory.
     import (
         "fmt"
 
-        "github.com/awnumar/memguard"
+        "github.com/JonathanLogan/memguard"
     )
 
     func main() {

--- a/errors.go
+++ b/errors.go
@@ -13,3 +13,6 @@ var ErrInvalidLength = errors.New("memguard.ErrInvalidLength: length of buffer m
 
 // ErrInvalidConversion is returned when attempting to get a slice of a LockedBuffer that is of an inappropriate size for that slice type. For example, attempting to get a []uint16 representation of a LockedBuffer of length 9 bytes would trigger this error, since there would be a byte leftover after the conversion.
 var ErrInvalidConversion = errors.New("memguard.ErrInvalidConversion: length of buffer must align with target type")
+
+// ErrYnreadable is returned when a function that needs to read a LockedBuffer is given a LockedBuffer that is unreadable.
+var ErrUnreadable = errors.New("memguard.ErrUnreadable: cannot read unreadable buffer")

--- a/memguardarray.go
+++ b/memguardarray.go
@@ -1,0 +1,188 @@
+package memguard
+
+import (
+	"unsafe"
+
+	"github.com/awnumar/memguard/memcall"
+)
+
+/*
+ByteArray16 returns an array (of type *[16]byte) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 2 bytes in length, and at least 16 byte longs, or else an error will be returned.
+*/
+func (b *container) ByteArray16() (*[16]byte, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%2 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	if len(b.buffer) < 16 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Return the array.
+	return (*[16]byte)(unsafe.Pointer(&b.buffer[0])), nil
+}
+
+/*
+ByteArray32 returns an array (of type *[32]byte) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 2 bytes in length, and at least 32 byte longs, or else an error will be returned.
+*/
+func (b *container) ByteArray32() (*[32]byte, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%2 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	if len(b.buffer) < 32 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Return the array.
+	return (*[32]byte)(unsafe.Pointer(&b.buffer[0])), nil
+}
+
+/*
+ByteArray64 returns an array (of type *[64]byte) that references the secure, protected portion of memory.
+
+The LockedBuffer must be a multiple of 2 bytes in length, and at least 64 byte longs, or else an error will be returned.
+*/
+func (b *container) ByteArray64() (*[64]byte, error) {
+	// Attain the mutex lock.
+	b.Lock()
+	defer b.Unlock()
+
+	// Check to see if it's destroyed.
+	if len(b.buffer) == 0 {
+		return nil, ErrDestroyed
+	}
+
+	// Check to see if it's an appropriate length.
+	if len(b.buffer)%2 != 0 {
+		return nil, ErrInvalidConversion
+	}
+
+	if len(b.buffer) < 64 {
+		return nil, ErrInvalidConversion
+	}
+
+	// Return the array.
+	return (*[64]byte)(unsafe.Pointer(&b.buffer[0])), nil
+}
+
+/*********************************************************************************************************/
+
+/*
+MakeUnreadable asks the kernel to mark the LockedBuffer's memory as unreadable. Any subsequent attempts to modify this memory will result in the process crashing with a SIGSEGV memory violation.
+
+To make the memory readable again, MakeReadable is called.
+*/
+func (b *container) MakeUnreadable() error {
+	// Get a mutex lock on this LockedBuffer.
+	b.Lock()
+	defer b.Unlock()
+	return b.makeUnreadable()
+}
+
+func (b *container) makeUnreadable() error {
+	// Check if it's destroyed.
+	if len(b.buffer) == 0 {
+		return ErrDestroyed
+	}
+
+	if b.readable {
+		// Mark the memory as unreadable.
+		memcall.Protect(getAllMemory(b)[pageSize:pageSize+roundToPageSize(len(b.buffer)+32)], false, b.mutable)
+
+		// Tell everyone about the change we made.
+		b.readable = false
+	}
+
+	// Everything went well.
+	return nil
+}
+
+/*
+MakeMutable asks the kernel to mark the LockedBuffer's memory as readable.
+
+To make the memory unreadable again, MakeUnreadable is called.
+*/
+func (b *container) MakeReadable() error {
+	// Get a mutex lock on this LockedBuffer.
+	b.Lock()
+	defer b.Unlock()
+
+	return b.makeReadable()
+}
+
+func (b *container) makeReadable() error {
+	// Check if it's destroyed.
+	if len(b.buffer) == 0 {
+		return ErrDestroyed
+	}
+
+	if !b.readable {
+		// Mark the memory as readable.
+		memcall.Protect(getAllMemory(b)[pageSize:pageSize+roundToPageSize(len(b.buffer)+32)], true, b.mutable)
+
+		// Tell everyone about the change we made.
+		b.readable = true
+	}
+
+	// Everything went well.
+	return nil
+}
+
+/*
+IsReadable returns a boolean value indicating if a LockedBuffer is marked un-readable.
+*/
+func (b *container) IsReadable() bool {
+	// Get a mutex lock on this LockedBuffer.
+	b.Lock()
+	defer b.Unlock()
+
+	return b.readable
+}
+
+/*
+WithReadable executes the function "fun" after making a LockedBuffer read-able. After
+the function returns, the LockedBuffer is marked un-readable again.
+
+The LockedBuffer will remain locked during the function execution, preventing other method
+calls on the container. Therefor all calls to LockedBuffer must be made BEFORE running WithReadable.
+*/
+func (b *container) WithReadable(fun func()) error {
+	b.Lock()
+	defer b.Unlock()
+	// make the buffer readable.
+	if err := b.makeReadable(); err != nil {
+		return err
+	}
+	// execute the function.
+	fun()
+	// make the buffer unreadable again.
+	if err := b.makeUnreadable(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/memguardarray_test.go
+++ b/memguardarray_test.go
@@ -1,0 +1,75 @@
+package memguard
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestArray64(t *testing.T) {
+	b, _ := NewImmutableRandom(64)
+	defer b.Destroy()
+	a, _ := b.ByteArray64()
+	buf := b.Buffer()
+	if &buf[0] != &a[0] {
+		t.Error("Array64 not returning address on buffer.")
+	}
+	if !bytes.Equal(buf[:64], a[:]) {
+		t.Error("Array64 and buffer don't match in data.")
+	}
+	//
+	b, _ = NewImmutableRandom(32)
+	defer b.Destroy()
+	if _, err := b.ByteArray64(); err == nil {
+		t.Error("Array64 did not catch too small buffer.")
+	}
+}
+
+func TestArray32(t *testing.T) {
+	b, _ := NewImmutableRandom(32)
+	defer b.Destroy()
+	a, _ := b.ByteArray32()
+	buf := b.Buffer()
+	if &buf[0] != &a[0] {
+		t.Error("Array32 not returning address on buffer.")
+	}
+	if !bytes.Equal(buf[:32], a[:]) {
+		t.Error("Array32 and buffer don't match in data.")
+	}
+	//
+	b, _ = NewImmutableRandom(16)
+	defer b.Destroy()
+	if _, err := b.ByteArray32(); err == nil {
+		t.Error("Array32 did not catch too small buffer.")
+	}
+}
+
+func TestArray16(t *testing.T) {
+	b, _ := NewImmutableRandom(16)
+	defer b.Destroy()
+	a, _ := b.ByteArray16()
+	buf := b.Buffer()
+	if &buf[0] != &a[0] {
+		t.Error("Array16 not returning address on buffer.")
+	}
+	if !bytes.Equal(buf[:16], a[:]) {
+		t.Error("Array16 and buffer don't match in data.")
+	}
+	//
+	b, _ = NewImmutableRandom(8)
+	defer b.Destroy()
+	if _, err := b.ByteArray16(); err == nil {
+		t.Error("Array16 did not catch too small buffer.")
+	}
+}
+
+/*************************************************************************/
+
+func TestWithReadable(t *testing.T) {
+	b, _ := NewMutableRandom(16)
+	defer b.Destroy()
+	b.MakeUnreadable()
+	a, _ := b.ByteArray16()
+	if err := b.WithReadable(func() { a[0] = a[1] }); err != nil {
+		t.Error("WithReadable may never fail.")
+	}
+}


### PR DESCRIPTION
New methods to return byte arrays of common sizes (16, 32, 64 bytes).
New methods to support buffers that are marked unreadable (!EACCESS) unless used.