### PR TITLE
canary: remove lower bound limit on length

### DIFF
--- a/core/buffer.go
+++ b/core/buffer.go
@@ -53,7 +53,7 @@ func NewBuffer(size int) (*Buffer, error) {
 	b := new(Buffer)
 
 	// Allocate the total needed memory
-	innerLen := roundToPageSize(size + 32)
+	innerLen := roundToPageSize(size)
 	b.memory, err = memcall.Alloc((2 * pageSize) + innerLen)
 	if err != nil {
 		Panic(err)
@@ -68,7 +68,7 @@ func NewBuffer(size int) (*Buffer, error) {
 	b.postguard = getBytes(&b.memory[pageSize+innerLen], pageSize)
 
 	// Construct slice reference for canary portion of inner page.
-	b.canary = getBytes(&b.memory[pageSize], len(b.inner)-len(b.data)-32)
+	b.canary = getBytes(&b.memory[pageSize], len(b.inner)-len(b.data))
 
 	// Lock the pages that will hold sensitive data.
 	if err := memcall.Lock(b.inner); err != nil {

--- a/core/buffer_test.go
+++ b/core/buffer_test.go
@@ -67,13 +67,13 @@ func TestLotsOfAllocs(t *testing.T) {
 		if len(b.data) != i {
 			t.Error("invalid data length")
 		}
-		if len(b.memory) != roundToPageSize(i+32)+2*pageSize {
+		if len(b.memory) != roundToPageSize(i)+2*pageSize {
 			t.Error("memory length invalid")
 		}
 		if len(b.preguard) != pageSize || len(b.postguard) != pageSize {
 			t.Error("guard pages length invalid")
 		}
-		if len(b.canary) != len(b.inner)-i-32 {
+		if len(b.canary) != len(b.inner)-i {
 			t.Error("canary length invalid")
 		}
 		b.Destroy()


### PR DESCRIPTION
In reference to the patch in #86, the actual issue is deeper. When we set a lower limit to the length of the canary, you need more than a single page to store the reference. It's not clean. The solution in this PR is to remove the lower limit so the canary can grow from length zero (when `len(data)` equals the page size) up to one less than the page size (when `len(data)` equals 1).

When the canary has a length of zero, this is fine as the data is up against the lower guard page. Otherwise, **with some values**, the canary will be small but this is a reasonable trade-off.