### PR TITLE
Add LockedBuffer constructors that use Reader objects as sources

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -78,7 +78,7 @@ func NewBufferFromReader(r io.Reader, size int) *LockedBuffer {
 	// Construct a buffer of the provided size.
 	b := NewBuffer(size)
 
-	// Attempt to fill it ith data from the Reader.
+	// Attempt to fill it with data from the Reader.
 	if n, err := io.ReadFull(r, b.Bytes()); err != nil {
 		if n == 0 {
 			// nothing was read
@@ -111,7 +111,7 @@ func NewBufferFromReaderUntil(r io.Reader, delim byte) *LockedBuffer {
 	// Loop over the buffer a byte at a time.
 	for i := 0; ; i++ {
 		// If we have filled this buffer...
-		if i == b.Size()-1 {
+		if i == b.Size() {
 			// Construct a new buffer that is a page size larger.
 			c := NewBuffer(b.Size() + os.Getpagesize())
 

--- a/buffer.go
+++ b/buffer.go
@@ -89,11 +89,13 @@ func NewBufferFromReader(r io.Reader, size int) *LockedBuffer {
 		// partial read
 		d := NewBuffer(n)
 		d.Copy(b.Bytes()[:n])
+		d.Freeze()
 		b.Destroy()
 		return d
 	}
 
 	// success
+	b.Freeze()
 	return b
 }
 
@@ -135,6 +137,7 @@ func NewBufferFromReaderUntil(r io.Reader, delim byte) *LockedBuffer {
 			// if there was an error, we're done early
 			d := NewBuffer(i)
 			d.Copy(b.Bytes()[:i])
+			d.Freeze()
 			b.Destroy()
 			return d
 		}
@@ -142,6 +145,7 @@ func NewBufferFromReaderUntil(r io.Reader, delim byte) *LockedBuffer {
 		if b.Bytes()[i] == delim {
 			d := NewBuffer(i)
 			d.Copy(b.Bytes()[:i])
+			d.Freeze()
 			b.Destroy()
 			return d
 		}

--- a/buffer.go
+++ b/buffer.go
@@ -1,6 +1,8 @@
 package memguard
 
 import (
+	"io"
+	"os"
 	"runtime"
 	"unsafe"
 
@@ -63,6 +65,87 @@ func NewBufferFromBytes(src []byte) *LockedBuffer {
 
 	// Return the created Buffer object.
 	return b
+}
+
+/*
+NewBufferFromReader reads a given number of bytes from a Reader into a LockedBuffer. The returned object will be immutable.
+
+If an error is encountered before size bytes are read, a smaller LockedBuffer object will be returned and the number of bytes read can be inferred using the Size method. If no bytes are read, nil is returned.
+
+The provided size must be strictly positive or the function will panic.
+*/
+func NewBufferFromReader(r io.Reader, size int) *LockedBuffer {
+	// Construct a buffer of the provided size.
+	b := NewBuffer(size)
+
+	// Attempt to fill it ith data from the Reader.
+	if n, err := io.ReadFull(r, b.Bytes()); err != nil {
+		if n == 0 {
+			// nothing was read
+			b.Destroy()
+			return nil
+		}
+
+		// partial read
+		d := NewBuffer(n)
+		d.Copy(b.Bytes()[:n])
+		b.Destroy()
+		return d
+	}
+
+	// success
+	return b
+}
+
+/*
+NewBufferFromReaderUntil constructs an immutable buffer containing data sourced from a Reader object. It will continue reading until either an EOF is encountered or the provided delimiter value is encountered. The delimiter will not be included in the returned data.
+
+The number of bytes read can be inferred using the Size method. If no data was read, nil is returned.
+*/
+func NewBufferFromReaderUntil(r io.Reader, delim byte) *LockedBuffer {
+	// Construct a buffer with a data page that fills an entire memory page.
+	b := NewBuffer(os.Getpagesize())
+
+	// Loop over the buffer a byte at a time.
+	for i := 0; ; i++ {
+		// If we have filled this buffer...
+		if i == b.Size()-1 {
+			// Construct a new buffer that is a page size larger.
+			c := NewBuffer(b.Size() + os.Getpagesize())
+
+			// Copy the data over.
+			c.Copy(b.Bytes())
+
+			// Destroy the old one and reassign its variable.
+			b.Destroy()
+			b = c
+		}
+
+		// Attempt to read a single byte.
+		n, err := r.Read(b.Bytes()[i : i+1])
+		if n != 1 { // if we did not read a byte
+			if err == nil { // and there was no error
+				i-- // try again
+				continue
+			}
+			if i == 0 { // no data read
+				b.Destroy()
+				return nil
+			}
+			// if there was an error, we're done early
+			d := NewBuffer(i)
+			d.Copy(b.Bytes()[:i])
+			b.Destroy()
+			return d
+		}
+		// we managed to read a byte, check if it was the delimiter
+		if b.Bytes()[i] == delim {
+			d := NewBuffer(i)
+			d.Copy(b.Bytes()[:i])
+			b.Destroy()
+			return d
+		}
+	}
 }
 
 /*

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -85,6 +85,9 @@ func TestNewBufferFromReader(t *testing.T) {
 	if bytes.Equal(b.Bytes(), make([]byte, 4096)) {
 		t.Error("didn't read from reader")
 	}
+	if b.IsMutable() {
+		t.Error("expected buffer to be immutable")
+	}
 	b.Destroy()
 
 	r := bytes.NewReader([]byte("yellow submarine"))
@@ -98,6 +101,9 @@ func TestNewBufferFromReader(t *testing.T) {
 	if !bytes.Equal(b.Bytes(), []byte("yellow submarine")) {
 		t.Error("incorrect data")
 	}
+	if b.IsMutable() {
+		t.Error("expected buffer to be immutable")
+	}
 	b.Destroy()
 
 	r = bytes.NewReader([]byte("yellow submarine"))
@@ -110,6 +116,9 @@ func TestNewBufferFromReader(t *testing.T) {
 	}
 	if !bytes.Equal(b.Bytes(), []byte("yellow submarine")) {
 		t.Error("incorrect data")
+	}
+	if b.IsMutable() {
+		t.Error("expected buffer to be immutable")
 	}
 	b.Destroy()
 
@@ -153,6 +162,9 @@ func TestNewBufferFromReaderUntil(t *testing.T) {
 			t.Error("incorrect data")
 		}
 	}
+	if b.IsMutable() {
+		t.Error("expected buffer to be immutable")
+	}
 	b.Destroy()
 
 	r = bytes.NewReader(data[:32])
@@ -167,6 +179,9 @@ func TestNewBufferFromReaderUntil(t *testing.T) {
 		if b.Bytes()[i] != 0 {
 			t.Error("incorrect data")
 		}
+	}
+	if b.IsMutable() {
+		t.Error("expected buffer to be immutable")
 	}
 	b.Destroy()
 
@@ -188,6 +203,9 @@ func TestNewBufferFromReaderUntil(t *testing.T) {
 		if b.Bytes()[i] != 0 {
 			t.Error("invalid data")
 		}
+	}
+	if b.IsMutable() {
+		t.Error("expected buffer to be immutable")
 	}
 	b.Destroy()
 }

--- a/core/buffer_test.go
+++ b/core/buffer_test.go
@@ -76,6 +76,17 @@ func TestLotsOfAllocs(t *testing.T) {
 		if len(b.canary) != len(b.inner)-i {
 			t.Error("canary length invalid")
 		}
+		if len(b.inner)%pageSize != 0 {
+			t.Error("inner length is not multiple of page size")
+		}
+		for j := range b.data {
+			b.data[j] = 1
+		}
+		for j := range b.data {
+			if b.data[j] != 1 {
+				t.Error("region rw test failed")
+			}
+		}
 		b.Destroy()
 	}
 }

--- a/core/enclave_test.go
+++ b/core/enclave_test.go
@@ -135,3 +135,34 @@ func TestOpen(t *testing.T) {
 		t.Error("expected nil buffer in error case")
 	}
 }
+
+func TestRepetitiveSealOpen(t *testing.T) {
+	// Initialise some data
+	data := make([]byte, 4096)
+	Scramble(data)
+
+	// Create a buffer containing the data
+	buf, err := NewBuffer(4096)
+	if err != nil {
+		t.Error(err)
+	}
+	Copy(buf.Data(), data)
+
+	// keep sealing and unsealing
+	for i := 0; i < 4096; i++ {
+		sealed, err := Seal(buf)
+		if err != nil {
+			t.Error(err)
+		}
+		if GetBufferState(buf).IsAlive {
+			t.Error("buf not destroyed")
+		}
+		buf, err = Open(sealed)
+		if err != nil {
+			t.Error(err)
+		}
+		if !bytes.Equal(buf.Data(), data) {
+			t.Error("data changed")
+		}
+	}
+}

--- a/core/enclave_test.go
+++ b/core/enclave_test.go
@@ -149,7 +149,7 @@ func TestRepetitiveSealOpen(t *testing.T) {
 	Copy(buf.Data(), data)
 
 	// keep sealing and unsealing
-	for i := 0; i < 4096; i++ {
+	for i := 0; i < 1024; i++ {
 		sealed, err := Seal(buf)
 		if err != nil {
 			t.Error(err)

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,3 +32,4 @@ You own your intellectual property and so you are free to choose any licence for
 
 0. [`Apache-2.0`] [socketkey](socketkey) :: Streaming multi-threaded client->server transfer of secure data over a socket.
 1. [`Apache-2.0`] [casting](casting) :: Some examples of representing the data in allocated buffers as different types.
+2. [`Apache-2.0`] [stdin](stdin) :: Reading from standard input directly into a guarded memory region and then sealing it.

--- a/examples/socketkey/socketkey.go
+++ b/examples/socketkey/socketkey.go
@@ -47,6 +47,9 @@ func SocketKey(size int) {
 		listener.Close()
 	})
 
+	// Purge the session before returning.
+	defer memguard.Purge()
+
 	// Create a client to connect to our server.
 	go func() {
 		// Connect to our server
@@ -129,7 +132,4 @@ func SocketKey(size int) {
 
 	// Destroy the buffer.
 	buf.Destroy()
-
-	// Purge the session and wipe the keys before exiting.
-	// memguard.SafeExit(0)
 }

--- a/examples/stdin/stdin.go
+++ b/examples/stdin/stdin.go
@@ -1,0 +1,16 @@
+package stdin
+
+import (
+	"os"
+
+	"github.com/awnumar/memguard"
+)
+
+// ReadKeyFromStdin reads a key from standard inputs and returns it sealed inside an Enclave object.
+func ReadKeyFromStdin() *memguard.Enclave {
+	key := memguard.NewBufferFromReaderUntil(os.Stdin, '\n')
+	if key == nil {
+		memguard.SafePanic("no input received")
+	}
+	return key.Seal()
+}

--- a/examples/stdin/stdin.go
+++ b/examples/stdin/stdin.go
@@ -1,3 +1,19 @@
+/*
+	Copyright 2019 Awn Umar <awn@spacetime.dev>
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
 package stdin
 
 import (


### PR DESCRIPTION
This change also makes reading from stdin very easy:

```go
b := NewBufferFromReaderUntil(os.Stdin, '\n')
```
