### PR TITLE
Add String method

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -325,6 +325,14 @@ func (b *LockedBuffer) Reader() *bytes.Reader {
 }
 
 /*
+String returns a string representation of the protected region of memory. Be warned, mutating the memory region will result in the mutation of the string's value.
+*/
+func (b *LockedBuffer) String() string {
+	slice := b.Bytes()
+	return *(*string)(unsafe.Pointer(&slice))
+}
+
+/*
 Uint16 returns a slice pointing to the protected region of memory with the data represented as a sequence of unsigned 16 bit integers. Its length will be half that of the byte slice, excluding any remaining part that doesn't form a complete uint16 value.
 
 If called on a destroyed LockedBuffer, a nil slice will be returned.

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -613,6 +613,18 @@ func TestReader(t *testing.T) {
 	c.Destroy()
 }
 
+func TestString(t *testing.T) {
+	b := NewBufferRandom(32)
+	b.Melt()
+	s := b.String()
+	for i := range b.Bytes() {
+		b.Bytes()[i] = 'x'
+		if string(b.Bytes()) != s {
+			t.Error("string does not map same memory")
+		}
+	}
+}
+
 func TestUint16(t *testing.T) {
 	b := NewBuffer(32)
 	if b == nil {


### PR DESCRIPTION
The rationale for this is that I've seen people use this library and just call `string(b.Bytes())` whenever they need a string representation, which creates a copy of the data and should be avoided. The added method returns a string referencing the same portion of memory. This way we can mutate the string by mutating the underlying memory, and there are no copies made.