### PR TITLE
all: redesign errors in memguard and memguard/core

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -245,7 +245,7 @@ If Seal is called on a destroyed buffer, a nil enclave is returned.
 func (b *LockedBuffer) Seal() *Enclave {
 	e, err := core.Seal(b.Buffer)
 	if err != nil {
-		if err == core.ErrBufferExpired {
+		if core.IsBufferExpired(err) {
 			return nil
 		}
 		core.Panic(err)

--- a/core/buffer.go
+++ b/core/buffer.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/awnumar/memguard/memcall"
@@ -11,12 +10,6 @@ import (
 var (
 	buffers = new(bufferList)
 )
-
-// ErrNullBuffer is returned when attempting to construct a buffer of size less than one.
-var ErrNullBuffer = errors.New("<memguard::core::ErrNullBuffer> buffer size must be greater than zero")
-
-// ErrBufferExpired is returned when attempting to perform an operation on or with a buffer that has been destroyed.
-var ErrBufferExpired = errors.New("<memguard::core::ErrBufferExpired> buffer has been purged from memory and can no longer be used")
 
 /*
 Buffer is a structure that holds raw sensitive data.
@@ -47,7 +40,7 @@ func NewBuffer(size int) (*Buffer, error) {
 
 	// Return an error if length < 1.
 	if size < 1 {
-		return nil, ErrNullBuffer
+		return nil, errors[errCodeNullBuffer]
 	}
 
 	// Declare and allocate

--- a/core/buffer_test.go
+++ b/core/buffer_test.go
@@ -9,7 +9,7 @@ import (
 func TestNewBuffer(t *testing.T) {
 	// Check the error case with zero length.
 	b, err := NewBuffer(0)
-	if err != ErrNullBuffer {
+	if !IsNullBuffer(err) {
 		t.Error("expected ErrNullBuffer; got", err)
 	}
 	if b != nil {
@@ -18,7 +18,7 @@ func TestNewBuffer(t *testing.T) {
 
 	// Check the error case with negative length.
 	b, err = NewBuffer(-1)
-	if err != ErrNullBuffer {
+	if !IsNullBuffer(err) {
 		t.Error("expected ErrNullBuffer; got", err)
 	}
 	if b != nil {

--- a/core/coffer.go
+++ b/core/coffer.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -21,9 +20,6 @@ var Interval uint64 = 8 // milliseconds
 func SetInterval(interval uint64) {
 	atomic.StoreUint64(&Interval, interval)
 }
-
-// ErrCofferExpired is returned when a function attempts to perform an operation using a secure key container that has been wiped and destroyed.
-var ErrCofferExpired = errors.New("<memguard::core::ErrCofferExpired> attempted usage of destroyed key object")
 
 /*
 Coffer is a specialized container for securing highly-sensitive, 32 byte values.
@@ -68,7 +64,7 @@ Initialise is used to reset the value stored inside a Coffer to a new random 32 
 func (s *Coffer) Initialise() error {
 	// Check if it has been destroyed.
 	if s.Destroyed() {
-		return ErrCofferExpired
+		return errors[errCodeCofferExpired]
 	}
 
 	// Attain the mutex.
@@ -99,7 +95,7 @@ func (s *Coffer) View() (*Buffer, error) {
 
 	// Check if it's destroyed.
 	if s.Destroyed() {
-		return nil, ErrCofferExpired
+		return nil, errors[errCodeCofferExpired]
 	}
 
 	// Create a new Buffer for the data.
@@ -122,7 +118,7 @@ Rekey is used to re-key a Coffer. Ideally this should be done at short, regular 
 func (s *Coffer) Rekey() error {
 	// Check if it has been destroyed.
 	if s.Destroyed() {
-		return ErrCofferExpired
+		return errors[errCodeCofferExpired]
 	}
 
 	// Attain the mutex.

--- a/core/coffer_test.go
+++ b/core/coffer_test.go
@@ -82,7 +82,7 @@ func TestCofferInitialise(t *testing.T) {
 	s.Destroy()
 
 	// Check error condition.
-	if err := s.Initialise(); err != ErrCofferExpired {
+	if err := s.Initialise(); !IsCofferExpired(err) {
 		t.Error("expected ErrCofferExpired; got", err)
 	}
 }
@@ -114,7 +114,7 @@ func TestCofferView(t *testing.T) {
 
 	// Check error condition.
 	view, err = s.View()
-	if err != ErrCofferExpired {
+	if !IsCofferExpired(err) {
 		t.Error("expected ErrCofferExpired; got", err)
 	}
 	if view != nil {
@@ -170,7 +170,7 @@ func TestCofferRekey(t *testing.T) {
 	s.RUnlock() // Release lock to allow destruction.
 	s.Destroy()
 
-	if err := s.Rekey(); err != ErrCofferExpired {
+	if err := s.Rekey(); !IsCofferExpired(err) {
 		t.Error("expected ErrCofferExpired; got", err)
 	}
 }

--- a/core/crypto.go
+++ b/core/crypto.go
@@ -3,7 +3,6 @@ package core
 import (
 	"crypto/rand"
 	"crypto/subtle"
-	"errors"
 	"runtime"
 	"unsafe"
 
@@ -14,20 +13,11 @@ import (
 // Overhead is the size by which the ciphertext exceeds the plaintext.
 const Overhead int = secretbox.Overhead + 24 // auth + nonce
 
-// ErrInvalidKeyLength is returned when attempting to encrypt or decrypt with a key that is not exactly 32 bytes in size.
-var ErrInvalidKeyLength = errors.New("<memguard::core::ErrInvalidKeyLength> key must be exactly 32 bytes")
-
-// ErrBufferTooSmall is returned when the decryption function, Open, is given an output buffer that is too small to hold the plaintext. In practice the plaintext will be Overhead bytes smaller than the ciphertext returned by the encryption function, Seal.
-var ErrBufferTooSmall = errors.New("<memguard::core::ErrBufferTooSmall> the given buffer is too small to hold the plaintext")
-
-// ErrDecryptionFailed is returned when the attempted decryption fails. This can occur if the given key is incorrect or if the ciphertext is invalid.
-var ErrDecryptionFailed = errors.New("<memguard::core::ErrDecryptionFailed> decryption failed")
-
 // Encrypt takes a plaintext message and a 32 byte key and returns an authenticated ciphertext.
 func Encrypt(plaintext, key []byte) ([]byte, error) {
 	// Check the length of the key is correct.
 	if len(key) != 32 {
-		return nil, ErrInvalidKeyLength
+		return nil, errors[errCodeInvalidKeyLength]
 	}
 
 	// Get a reference to the key's underlying array without making a copy.
@@ -51,12 +41,12 @@ The size of the decrypted data is returned.
 func Decrypt(ciphertext, key []byte, output []byte) (int, error) {
 	// Check the length of the key is correct.
 	if len(key) != 32 {
-		return 0, ErrInvalidKeyLength
+		return 0, errors[errCodeInvalidKeyLength]
 	}
 
 	// Check the capacity of the given output buffer.
 	if cap(output) < (len(ciphertext) - Overhead) {
-		return 0, ErrBufferTooSmall
+		return 0, errors[errCodeBufferTooSmall]
 	}
 
 	// Get a reference to the key's underlying array without making a copy.
@@ -74,7 +64,7 @@ func Decrypt(ciphertext, key []byte, output []byte) (int, error) {
 	}
 
 	// Decryption unsuccessful. Either the key was wrong or the authentication failed.
-	return 0, ErrDecryptionFailed
+	return 0, errors[errCodeDecryptionFailed]
 }
 
 // Hash implements a cryptographic hash function using Blake2b.

--- a/core/crypto_test.go
+++ b/core/crypto_test.go
@@ -144,7 +144,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	// Attempt decryption /w buffer that is too small to hold the output.
 	out := make([]byte, len(x)-Overhead-1)
 	length, err = Decrypt(x, k, out)
-	if err != ErrBufferTooSmall {
+	if !IsBufferTooSmall(err) {
 		t.Error("expected error; got", err)
 	}
 	if length != 0 {
@@ -177,7 +177,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	if length != 0 {
 		t.Error("expected length = 0; got", length)
 	}
-	if err != ErrDecryptionFailed {
+	if !IsDecryptionFailed(err) {
 		t.Error("expected error with incorrect key; got", err)
 	}
 
@@ -193,7 +193,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	if length != 0 {
 		t.Error("expected length = 0; got", length)
 	}
-	if err != ErrDecryptionFailed {
+	if !IsDecryptionFailed(err) {
 		t.Error("expected error with modified ciphertext; got", err)
 	}
 
@@ -203,7 +203,7 @@ func TestEncryptDecrypt(t *testing.T) {
 
 	// Attempt encryption with the invalid key.
 	ix, err := Encrypt(m, ik)
-	if err != ErrInvalidKeyLength {
+	if !IsInvalidKeyLength(err) {
 		t.Error("expected error with invalid key; got", err)
 	}
 	if ix != nil {
@@ -215,7 +215,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	if length != 0 {
 		t.Error("expected length = 0; got", length)
 	}
-	if err != ErrInvalidKeyLength {
+	if !IsInvalidKeyLength(err) {
 		t.Error("expected error with invalid key; got", err)
 	}
 }

--- a/core/enclave.go
+++ b/core/enclave.go
@@ -1,7 +1,5 @@
 package core
 
-import "errors"
-
 var (
 	// Declare a key for use in encrypting data this session.
 	key *Coffer
@@ -11,9 +9,6 @@ func init() {
 	// Initialize the key declared above with a random value.
 	key = NewCoffer()
 }
-
-// ErrNullEnclave is returned when attempting to construct an enclave of size less than one.
-var ErrNullEnclave = errors.New("<memguard::core::ErrNullEnclave> enclave size must be greater than zero")
 
 /*
 Enclave is a sealed and encrypted container for sensitive data.
@@ -28,7 +23,7 @@ NewEnclave is a raw constructor for the Enclave object. The given buffer is wipe
 func NewEnclave(buf []byte) (*Enclave, error) {
 	// Return an error if length < 1.
 	if len(buf) < 1 {
-		return nil, ErrNullEnclave
+		return nil, errors[errCodeNullEnclave]
 	}
 
 	// Create a new Enclave.
@@ -61,7 +56,7 @@ Seal consumes a given Buffer object and returns its data secured and encrypted i
 func Seal(b *Buffer) (*Enclave, error) {
 	// Check if the Buffer has been destroyed.
 	if !b.Alive() {
-		return nil, ErrBufferExpired
+		return nil, errors[errCodeBufferExpired]
 	}
 
 	b.Melt()  // Make the buffer mutable so that we can wipe it.

--- a/core/enclave_test.go
+++ b/core/enclave_test.go
@@ -49,7 +49,7 @@ func TestNewEnclave(t *testing.T) {
 	// Attempt with an empty data slice.
 	data = make([]byte, 0)
 	e, err = NewEnclave(data)
-	if err != ErrNullEnclave {
+	if !IsNullEnclave(err) {
 		t.Error("expected ErrNullEnclave; got", err)
 	}
 }
@@ -90,7 +90,7 @@ func TestSeal(t *testing.T) {
 
 	// Attempt sealing the destroyed buffer.
 	e, err = Seal(b)
-	if err != ErrBufferExpired {
+	if !IsBufferExpired(err) {
 		t.Error("expected ErrBufferExpired; got", err)
 	}
 	if e != nil {
@@ -128,7 +128,7 @@ func TestOpen(t *testing.T) {
 
 	// Check for the error.
 	buf, err = Open(e)
-	if err != ErrDecryptionFailed {
+	if !IsDecryptionFailed(err) {
 		t.Error("expected decryption error; got", err)
 	}
 	if buf != nil {

--- a/core/err.go
+++ b/core/err.go
@@ -1,0 +1,91 @@
+package core
+
+const (
+	errCodeNoErr = iota
+	errCodeBufferExpired
+	errCodeBufferTooSmall
+	errCodeCofferExpired
+	errCodeDecryptionFailed
+	errCodeInvalidKeyLength
+	errCodeNullBuffer
+	errCodeNullEnclave
+
+	// Error string context.
+	ctx = "memguard/core: "
+)
+
+type errCode uint
+
+type memguardErr struct {
+	s string
+	c errCode
+}
+
+func (e memguardErr) Error() string {
+	return e.s
+}
+
+var errors = [...]memguardErr {
+	{ctx + "no error", errCodeNoErr},
+	{ctx + "buffer has been purged from memory and can no longer be used", errCodeBufferExpired},
+	{ctx + "the given buffer is too small to hold the plaintext", errCodeBufferTooSmall},
+	{ctx + "attempted usage of destroyed key object", errCodeCofferExpired},
+	{ctx + "decryption failed", errCodeDecryptionFailed},
+	{ctx + "key must be exactly 32 bytes", errCodeInvalidKeyLength},
+	{ctx + "buffer size must be greater than zero", errCodeNullBuffer},
+	{ctx + "enclave size must be greater than zero", errCodeNullEnclave},
+}
+
+func isXError(e error, c errCode) bool {
+	ei, ok := e.(memguardErr)
+	return ok && ei.c == c
+}
+
+// IsBufferExpired returns a boolean indicating whether the error is
+// known to report that an operation was attempted on or with a buffer
+// that has been destroyed.
+func IsBufferExpired(e error) bool {
+	return isXError(e, errCodeBufferExpired)
+}
+
+// IsBufferTooSmall returns a boolean indicating whether the error is
+// known to report that the decryption function, Open, was given an
+// output buffer that is too small to hold the plaintext.
+func IsBufferTooSmall(e error) bool {
+	return isXError(e, errCodeBufferTooSmall)
+}
+
+// IsCofferExpired returns a boolean indicating whether the error is
+// known to report that an operation was attempted using a secure key
+// container that has been wiped and destroyed.
+func IsCofferExpired(e error) bool {
+	return isXError(e, errCodeCofferExpired)
+}
+
+// IsDecryptionFailed returns a boolean indicating whether the error is
+// known to report that decryption failed. This can occur if the given
+// key is incorrect or if the ciphertext is invalid.
+func IsDecryptionFailed(e error) bool {
+	return isXError(e, errCodeDecryptionFailed)
+}
+
+// IsInvalidKeyLength returns a boolean indicating whether the error is
+// known to report that encryption or decryption with a key that is not
+// exactly 32 bytes was attempted.
+func IsInvalidKeyLength(e error) bool {
+	return isXError(e, errCodeInvalidKeyLength)
+}
+
+// IsNullBuffer returns a boolean indicating whether the error is known
+// to report that a buffer with size not greater than zero was
+// attempted to be constructed.
+func IsNullBuffer(e error) bool {
+	return isXError(e, errCodeNullBuffer)
+}
+
+// IsNullEnclave returns a boolean indicating whether the error is
+// known to report that an enclave of size less than one was attempted
+// to be constructed.
+func IsNullEnclave(e error) bool {
+	return isXError(e, errCodeNullEnclave)
+}

--- a/core/exit_test.go
+++ b/core/exit_test.go
@@ -44,7 +44,7 @@ func TestPurge(t *testing.T) {
 	}
 
 	// Verify that the key changed by decrypting the Enclave.
-	if _, err := Open(enclave); err != ErrDecryptionFailed {
+	if _, err := Open(enclave); !IsDecryptionFailed(err) {
 		t.Error("expected decryption failed; got", err)
 	}
 }

--- a/enclave.go
+++ b/enclave.go
@@ -19,7 +19,7 @@ A LockedBuffer may alternatively be converted into an Enclave object using its S
 func NewEnclave(src []byte) *Enclave {
 	e, err := core.NewEnclave(src)
 	if err != nil {
-		if err == core.ErrNullEnclave {
+		if core.IsNullEnclave(err) {
 			return nil
 		}
 		core.Panic(err)
@@ -42,7 +42,7 @@ Open decrypts an Enclave object and places its contents into an immutable Locked
 func (e *Enclave) Open() (*LockedBuffer, error) {
 	b, err := core.Open(e.Enclave)
 	if err != nil {
-		if err != core.ErrDecryptionFailed {
+		if !core.IsDecryptionFailed(err) {
 			core.Panic(err)
 		}
 		return nil, err

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -65,7 +65,7 @@ func TestOpen(t *testing.T) {
 	}
 	Purge() // reset the session
 	b, err = e.Open()
-	if err != core.ErrDecryptionFailed {
+	if !core.IsDecryptionFailed(err) {
 		t.Error("expected decryption error; got", err)
 	}
 	if b != nil {

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -35,7 +35,7 @@ func TestPurge(t *testing.T) {
 		t.Error("buffer not destroyed")
 	}
 	buf, err = key.Open()
-	if err != core.ErrDecryptionFailed {
+	if !core.IsDecryptionFailed(err) {
 		t.Error(buf.Bytes(), err)
 	}
 	if buf != nil {


### PR DESCRIPTION
Memcall is not touched yet. Otherwise this replaces sentinel error
values with IsX exported predicate functions. This enables more
effective error handling by the users and leaves much more freedom for
changing the implementation in the future without breaking API.

Updates #111