### PR TITLE
Some localisation

### DIFF
--- a/core/coffer.go
+++ b/core/coffer.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// interval of time between each verify & re-key cycle.
-	interval uintptr = 50 // milliseconds
+	interval uint32 = 50 // milliseconds
 
 	// Static allocation for fast random bytes reading.
 	buf32, _ = NewBuffer(32)
@@ -20,8 +20,19 @@ var (
 // SetInterval changes the interval time in milliseconds between re-key cycles.
 // The default is 50 milliseconds and a value below one second is recommended.
 // Only call this function if you have a very specific reason to do so.
-func SetInterval(newInterval uintptr) {
-	atomic.StoreUintptr(&interval, newInterval)
+//
+// Dependencies of your program may mutate this value globally for your program.
+// If you disagree with their choice, you may specify your preferred value in
+// your package root.
+//
+// MOST USERS SHOULD COMPLETELY LEAVE THIS VALUE ALONE AND UNTOUCHED.
+func SetInterval(new uint32) {
+	atomic.StoreUint32(&interval, new)
+}
+
+// GetInterval returns the current interval in milliseconds between successive Coffer re-key cycles. The default is 50 milliseconds.
+func GetInterval() uint32 {
+	return atomic.LoadUint32(&interval)
 }
 
 // ErrCofferExpired is returned when a function attempts to perform an operation using a secure key container that has been wiped and destroyed.
@@ -52,7 +63,7 @@ func NewCoffer() *Coffer {
 	go func(s *Coffer) {
 		for {
 			// Sleep for the specified interval.
-			time.Sleep(time.Duration(atomic.LoadUintptr(&interval)) * time.Millisecond)
+			time.Sleep(time.Duration(GetInterval()) * time.Millisecond)
 
 			// Re-key the contents, exiting the routine if object destroyed.
 			if err := s.Rekey(); err != nil {

--- a/core/coffer.go
+++ b/core/coffer.go
@@ -10,16 +10,18 @@ import (
 )
 
 var (
+	// interval of time between each verify & re-key cycle.
+	interval uint64 = 50 // milliseconds
+
 	// Static allocation for fast random bytes reading.
 	buf32, _ = NewBuffer(32)
 )
 
-// Interval of time between each verify & re-key cycle.
-var Interval uint64 = 8 // milliseconds
-
-// SetInterval changes the interval in milliseconds between re-key cycles. The default is 8 milliseconds and a value below one second is recommended.
-func SetInterval(interval uint64) {
-	atomic.StoreUint64(&Interval, interval)
+// SetInterval changes the interval time in milliseconds between re-key cycles.
+// The default is 50 milliseconds and a value below one second is recommended.
+// Only call this function if you have a very specific reason to do so.
+func SetInterval(newInterval uint64) {
+	atomic.StoreUint64(&interval, newInterval)
 }
 
 // ErrCofferExpired is returned when a function attempts to perform an operation using a secure key container that has been wiped and destroyed.
@@ -50,7 +52,7 @@ func NewCoffer() *Coffer {
 	go func(s *Coffer) {
 		for {
 			// Sleep for the specified interval.
-			time.Sleep(time.Duration(atomic.LoadUint64(&Interval)) * time.Millisecond)
+			time.Sleep(time.Duration(atomic.LoadUint64(&interval)) * time.Millisecond)
 
 			// Re-key the contents, exiting the routine if object destroyed.
 			if err := s.Rekey(); err != nil {

--- a/core/coffer.go
+++ b/core/coffer.go
@@ -3,34 +3,13 @@ package core
 import (
 	"errors"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"gitlab.com/NebulousLabs/fastrand"
 )
 
-var (
-	// interval of time between each verify & re-key cycle.
-	interval uint32 = 50 // milliseconds
-)
-
-// SetInterval changes the interval time in milliseconds between re-key cycles.
-// The default is 50 milliseconds and a value below one second is recommended.
-// Only call this function if you have a very specific reason to do so.
-//
-// Dependencies of your program may mutate this value globally for your program.
-// If you disagree with their choice, you may specify your preferred value in
-// your package root.
-//
-// MOST USERS SHOULD RESPECT THE DEFAULTS AND COMPLETELY LEAVE THIS VALUE UNTOUCHED.
-func SetInterval(new uint32) {
-	atomic.StoreUint32(&interval, new)
-}
-
-// GetInterval returns the current interval in milliseconds between successive Coffer re-key cycles. The default is 50 milliseconds.
-func GetInterval() uint32 {
-	return atomic.LoadUint32(&interval)
-}
+// Interval of time between each verify & re-key cycle.
+const Interval = 500 // milliseconds
 
 // ErrCofferExpired is returned when a function attempts to perform an operation using a secure key container that has been wiped and destroyed.
 var ErrCofferExpired = errors.New("<memguard::core::ErrCofferExpired> attempted usage of destroyed key object")
@@ -63,7 +42,7 @@ func NewCoffer() *Coffer {
 	go func(s *Coffer) {
 		for {
 			// Sleep for the specified interval.
-			time.Sleep(time.Duration(GetInterval()) * time.Millisecond)
+			time.Sleep(Interval * time.Millisecond)
 
 			// Re-key the contents, exiting the routine if object destroyed.
 			if err := s.Rekey(); err != nil {

--- a/core/coffer.go
+++ b/core/coffer.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// interval of time between each verify & re-key cycle.
-	interval uint64 = 50 // milliseconds
+	interval uintptr = 50 // milliseconds
 
 	// Static allocation for fast random bytes reading.
 	buf32, _ = NewBuffer(32)
@@ -20,8 +20,8 @@ var (
 // SetInterval changes the interval time in milliseconds between re-key cycles.
 // The default is 50 milliseconds and a value below one second is recommended.
 // Only call this function if you have a very specific reason to do so.
-func SetInterval(newInterval uint64) {
-	atomic.StoreUint64(&interval, newInterval)
+func SetInterval(newInterval uintptr) {
+	atomic.StoreUintptr(&interval, newInterval)
 }
 
 // ErrCofferExpired is returned when a function attempts to perform an operation using a secure key container that has been wiped and destroyed.
@@ -52,7 +52,7 @@ func NewCoffer() *Coffer {
 	go func(s *Coffer) {
 		for {
 			// Sleep for the specified interval.
-			time.Sleep(time.Duration(atomic.LoadUint64(&interval)) * time.Millisecond)
+			time.Sleep(time.Duration(atomic.LoadUintptr(&interval)) * time.Millisecond)
 
 			// Re-key the contents, exiting the routine if object destroyed.
 			if err := s.Rekey(); err != nil {

--- a/core/coffer_test.go
+++ b/core/coffer_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestSetInterval(t *testing.T) {
-	if atomic.LoadUint64(&interval) != 8 {
+	if atomic.LoadUintptr(&interval) != 8 {
 		t.Error("default should be 8ms")
 	}
 	SetInterval(500)
-	if atomic.LoadUint64(&interval) != 500 {
+	if atomic.LoadUintptr(&interval) != 500 {
 		t.Error("value did not update")
 	}
 	SetInterval(8)

--- a/core/coffer_test.go
+++ b/core/coffer_test.go
@@ -2,16 +2,15 @@ package core
 
 import (
 	"bytes"
-	"sync/atomic"
 	"testing"
 )
 
 func TestSetInterval(t *testing.T) {
-	if atomic.LoadUintptr(&interval) != 50 {
+	if GetInterval() != 50 {
 		t.Error("default should be 50ms")
 	}
 	SetInterval(500)
-	if atomic.LoadUintptr(&interval) != 500 {
+	if GetInterval() != 500 {
 		t.Error("value did not update")
 	}
 	SetInterval(50)

--- a/core/coffer_test.go
+++ b/core/coffer_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestSetInterval(t *testing.T) {
-	if atomic.LoadUintptr(&interval) != 8 {
-		t.Error("default should be 8ms")
+	if atomic.LoadUintptr(&interval) != 50 {
+		t.Error("default should be 50ms")
 	}
 	SetInterval(500)
 	if atomic.LoadUintptr(&interval) != 500 {
 		t.Error("value did not update")
 	}
-	SetInterval(8)
+	SetInterval(50)
 }
 
 func TestNewCoffer(t *testing.T) {

--- a/core/coffer_test.go
+++ b/core/coffer_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestSetInterval(t *testing.T) {
-	if atomic.LoadUint64(&Interval) != 8 {
+	if atomic.LoadUint64(&interval) != 8 {
 		t.Error("default should be 8ms")
 	}
 	SetInterval(500)
-	if atomic.LoadUint64(&Interval) != 500 {
+	if atomic.LoadUint64(&interval) != 500 {
 		t.Error("value did not update")
 	}
 	SetInterval(8)

--- a/core/coffer_test.go
+++ b/core/coffer_test.go
@@ -5,17 +5,6 @@ import (
 	"testing"
 )
 
-func TestSetInterval(t *testing.T) {
-	if GetInterval() != 50 {
-		t.Error("default should be 50ms")
-	}
-	SetInterval(500)
-	if GetInterval() != 500 {
-		t.Error("value did not update")
-	}
-	SetInterval(50)
-}
-
 func TestNewCoffer(t *testing.T) {
 	s := NewCoffer()
 

--- a/core/enclave.go
+++ b/core/enclave.go
@@ -9,10 +9,9 @@ var (
 
 func init() {
 	// Initialize the key declared above with a random value.
-	if key != nil {
-		key.Destroy()
+	if key == nil {
+		key = NewCoffer()
 	}
-	key = NewCoffer()
 }
 
 // ErrNullEnclave is returned when attempting to construct an enclave of size less than one.

--- a/core/enclave.go
+++ b/core/enclave.go
@@ -9,6 +9,9 @@ var (
 
 func init() {
 	// Initialize the key declared above with a random value.
+	if key != nil {
+		key.Destroy()
+	}
 	key = NewCoffer()
 }
 

--- a/core/exit.go
+++ b/core/exit.go
@@ -23,12 +23,12 @@ func Purge() {
 
 	// Get a snapshot of existing Buffers.
 	snapshot := buffers.flush()
-	buffers.add(key.left, key.right, buf32)
+	buffers.add(key.left, key.right, key.rand)
 
 	// Destroy them, performing the usual sanity checks.
 	for _, b := range snapshot {
 		// Don't destroy the key partitions.
-		if b != key.left && b != key.right && b != buf32 {
+		if b != key.left && b != key.right && b != key.rand {
 			b.Destroy()
 		}
 	}

--- a/core/exit_test.go
+++ b/core/exit_test.go
@@ -28,7 +28,7 @@ func TestPurge(t *testing.T) {
 			t.Error("should not have destroyed excluded buffers")
 		}
 	}
-	if !key.right.Alive() || !key.left.Alive() || !buf32.Alive() {
+	if !key.right.Alive() || !key.left.Alive() || !key.rand.Alive() {
 		t.Error("buffers left in list aren't the right ones")
 	}
 	buffers.RUnlock()


### PR DESCRIPTION
- Remove interval specification functionality.
- Increase interval to half a second.
- Make the static allocation for fast random bytes reading local to the coffer object.
- Add check to prevent Coffer being created twice.