### PR TITLE
Fix recursive lock

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -314,10 +314,7 @@ func (b *LockedBuffer) Scramble() {
 		return
 	}
 
-	b.Lock()
-	defer b.Unlock()
-
-	core.Scramble(b.Bytes())
+	b.Buffer.Scramble()
 }
 
 /*

--- a/buffer.go
+++ b/buffer.go
@@ -404,13 +404,14 @@ Uint16 returns a slice pointing to the protected region of memory with the data 
 If called on a destroyed LockedBuffer, a nil slice will be returned.
 */
 func (b *LockedBuffer) Uint16() []uint16 {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Compute size of new slice representation.
 	size := b.Size() / 2
@@ -435,13 +436,14 @@ Uint32 returns a slice pointing to the protected region of memory with the data 
 If called on a destroyed LockedBuffer, a nil slice will be returned.
 */
 func (b *LockedBuffer) Uint32() []uint32 {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Compute size of new slice representation.
 	size := b.Size() / 4
@@ -466,13 +468,14 @@ Uint64 returns a slice pointing to the protected region of memory with the data 
 If called on a destroyed LockedBuffer, a nil slice will be returned.
 */
 func (b *LockedBuffer) Uint64() []uint64 {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Compute size of new slice representation.
 	size := b.Size() / 8
@@ -495,13 +498,14 @@ func (b *LockedBuffer) Uint64() []uint64 {
 Int8 returns a slice pointing to the protected region of memory with the data represented as a sequence of signed 8 bit integers. If called on a destroyed LockedBuffer, a nil slice will be returned.
 */
 func (b *LockedBuffer) Int8() []int8 {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Construct the new slice representation.
 	var sl = struct {
@@ -520,13 +524,14 @@ Int16 returns a slice pointing to the protected region of memory with the data r
 If called on a destroyed LockedBuffer, a nil slice will be returned.
 */
 func (b *LockedBuffer) Int16() []int16 {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Compute size of new slice representation.
 	size := b.Size() / 2
@@ -551,13 +556,14 @@ Int32 returns a slice pointing to the protected region of memory with the data r
 If called on a destroyed LockedBuffer, a nil slice will be returned.
 */
 func (b *LockedBuffer) Int32() []int32 {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Compute size of new slice representation.
 	size := b.Size() / 4
@@ -582,13 +588,14 @@ Int64 returns a slice pointing to the protected region of memory with the data r
 If called on a destroyed LockedBuffer, a nil slice will be returned.
 */
 func (b *LockedBuffer) Int64() []int64 {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Compute size of new slice representation.
 	size := b.Size() / 8
@@ -613,13 +620,14 @@ ByteArray8 returns a pointer to some 8 byte array. Care must be taken not to der
 The length of the buffer must be at least 8 bytes in size and the LockedBuffer should not be destroyed. In either of these cases a nil value is returned.
 */
 func (b *LockedBuffer) ByteArray8() *[8]byte {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Check if the length is large enough.
 	if len(b.Bytes()) < 8 {
@@ -636,13 +644,14 @@ ByteArray16 returns a pointer to some 16 byte array. Care must be taken not to d
 The length of the buffer must be at least 16 bytes in size and the LockedBuffer should not be destroyed. In either of these cases a nil value is returned.
 */
 func (b *LockedBuffer) ByteArray16() *[16]byte {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Check if the length is large enough.
 	if len(b.Bytes()) < 16 {
@@ -659,13 +668,14 @@ ByteArray32 returns a pointer to some 32 byte array. Care must be taken not to d
 The length of the buffer must be at least 32 bytes in size and the LockedBuffer should not be destroyed. In either of these cases a nil value is returned.
 */
 func (b *LockedBuffer) ByteArray32() *[32]byte {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Check if the length is large enough.
 	if len(b.Bytes()) < 32 {
@@ -682,13 +692,14 @@ ByteArray64 returns a pointer to some 64 byte array. Care must be taken not to d
 The length of the buffer must be at least 64 bytes in size and the LockedBuffer should not be destroyed. In either of these cases a nil value is returned.
 */
 func (b *LockedBuffer) ByteArray64() *[64]byte {
-	b.RLock()
-	defer b.RUnlock()
 
 	// Check if still alive.
 	if !b.Buffer.Alive() {
 		return nil
 	}
+
+	b.RLock()
+	defer b.RUnlock()
 
 	// Check if the length is large enough.
 	if len(b.Bytes()) < 64 {

--- a/core/crypto.go
+++ b/core/crypto.go
@@ -35,7 +35,9 @@ func Encrypt(plaintext, key []byte) ([]byte, error) {
 
 	// Allocate space for and generate a nonce value.
 	var nonce [24]byte
-	Scramble(nonce[:])
+	if err := Scramble(nonce[:]); err != nil {
+		Panic(err)
+	}
 
 	// Encrypt m and return the result.
 	return secretbox.Seal(nonce[:], plaintext, &nonce, k), nil
@@ -84,13 +86,14 @@ func Hash(b []byte) []byte {
 }
 
 // Scramble fills a given buffer with cryptographically-secure random bytes.
-func Scramble(buf []byte) {
+func Scramble(buf []byte) error {
 	if _, err := rand.Read(buf); err != nil {
-		Panic(err)
+		return err
 	}
 
 	// See Wipe
 	runtime.KeepAlive(buf)
+	return nil
 }
 
 // Wipe takes a buffer and wipes it with zeroes.

--- a/core/enclave.go
+++ b/core/enclave.go
@@ -66,6 +66,8 @@ func Seal(b *Buffer) (*Enclave, error) {
 		return nil, ErrBufferExpired
 	}
 
+	b.Melt() // Make the buffer mutable so that we can wipe it.
+
 	// Construct the Enclave from the Buffer's data.
 	e, err := func() (*Enclave, error) {
 		b.RLock() // Attain a read lock.
@@ -77,7 +79,6 @@ func Seal(b *Buffer) (*Enclave, error) {
 	}
 
 	// Destroy the Buffer object.
-	b.Melt() // Make the buffer mutable so that we can wipe it.
 	b.Destroy()
 
 	// Return the newly created Enclave.

--- a/core/exit.go
+++ b/core/exit.go
@@ -15,39 +15,47 @@ The creation of new Enclave objects should wait for this function to return sinc
 This function should be called before the program terminates, or else the provided Exit or Panic functions should be used to terminate.
 */
 func Purge() {
-	// Halt the re-key cycle and prevent new enclaves.
-	key.Lock()
+	var opErr error
 
-	// Get a snapshot of existing Buffers.
-	snapshot := buffers.flush()
+	func() {
+		// Halt the re-key cycle and prevent new enclaves.
+		key.Lock()
+		defer key.Unlock()
 
-	// Destroy them, performing the usual sanity checks.
-	var err error
-	for _, b := range snapshot {
-		if err = b.destroy(); err != nil {
-			// buffer destroy failed; wipe instead
-			b.Lock()
-			defer b.Unlock()
-			if !b.mutable {
-				if err := memcall.Protect(b.inner, memcall.ReadWrite()); err != nil {
-					// couldn't change it to mutable; we can't wipe it! (could this happen?)
-					// not sure what we can do at this point, just warn and move on
-					fmt.Fprintf(os.Stderr, "!WARNING: failed to wipe immutable data at address %p", &b.data)
-					continue
+		// Get a snapshot of existing Buffers.
+		snapshot := buffers.flush()
+
+		// Destroy them, performing the usual sanity checks.
+		for _, b := range snapshot {
+			if err := b.destroy(); err != nil {
+				if opErr == nil {
+					opErr = err
+				} else {
+					opErr = fmt.Errorf("%s; %s", opErr.Error(), err.Error())
 				}
+				// buffer destroy failed; wipe instead
+				b.Lock()
+				defer b.Unlock()
+				if !b.mutable {
+					if err := memcall.Protect(b.inner, memcall.ReadWrite()); err != nil {
+						// couldn't change it to mutable; we can't wipe it! (could this happen?)
+						// not sure what we can do at this point, just warn and move on
+						fmt.Fprintf(os.Stderr, "!WARNING: failed to wipe immutable data at address %p", &b.data)
+						continue
+					}
+				}
+				Wipe(b.data)
 			}
-			Wipe(b.data)
 		}
-	}
+	}()
 
 	// Destroy and recreate the key.
-	key.Unlock()
 	key.Destroy() // should be a no-op
 	key = NewCoffer()
 
 	// If we encountered an error, panic.
-	if err != nil {
-		panic(err)
+	if opErr != nil {
+		panic(opErr)
 	}
 }
 

--- a/memguard.go
+++ b/memguard.go
@@ -10,7 +10,9 @@ import (
 ScrambleBytes overwrites an arbitrary buffer with cryptographically-secure random bytes.
 */
 func ScrambleBytes(buf []byte) {
-	core.Scramble(buf)
+	if err := core.Scramble(buf); err != nil {
+		core.Panic(err)
+	}
 }
 
 /*


### PR DESCRIPTION
fix two types of Mutex bug

1. RLock following RLock
2. Lock following RLock

*core.Panic() is a big challenge, it requires coffer and all lockbuffers write permission if any error occurs.*