### PR TITLE
Fixes windows and FreeBSD ci failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,6 +44,8 @@ windows_task:
   install_script:
     - choco install -y golang
     - choco install -y mingw  # This installs MinGW which includes gcc
+    - Set PATH=C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;%PATH%
+    - gcc --version
   build_script:
     - go version
     - go get ./...

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,11 +45,11 @@ windows_task:
     - choco install -y golang
     - choco install -y mingw  # This installs MinGW which includes gcc
     - refreshenv
+    - echo $PATH
     - gcc --version
   build_script:
     - go version
     - go get ./...
-    - echo $PATH
     - env CGO_ENABLED=1 go build -race -v ./...
   test_script:
     - env CGO_ENABLED=1 go test -race -v ./...

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,7 +58,7 @@ windows_task:
 
 freebsd_task:
   freebsd_instance:
-    image: image: freebsd-14-0-release-amd64
+    image: freebsd-14-0-release-amd64
   env:
     GO111MODULE: on
     GOPATH: /tmp/go

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,6 +44,7 @@ windows_task:
   install_script:
     - choco install -y golang
     - choco install -y mingw  # This installs MinGW which includes gcc
+    - refreshenv
     - gcc --version
   build_script:
     - go version
@@ -57,7 +58,7 @@ windows_task:
 
 freebsd_task:
   freebsd_instance:
-    image: freebsd-12-2-release-amd64
+    image: image: freebsd-14-0-release-amd64
   env:
     GO111MODULE: on
     GOPATH: /tmp/go

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,11 +44,11 @@ windows_task:
   install_script:
     - choco install -y golang
     - choco install -y mingw  # This installs MinGW which includes gcc
-    - Set PATH=C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;%PATH%
     - gcc --version
   build_script:
     - go version
     - go get ./...
+    - echo $PATH
     - env CGO_ENABLED=1 go build -race -v ./...
   test_script:
     - env CGO_ENABLED=1 go test -race -v ./...

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,20 +45,22 @@ windows_task:
     - choco install -y golang
     - choco install -y mingw  # This installs MinGW which includes gcc
     - refreshenv
-    - echo $PATH
     - gcc --version
   build_script:
     - go version
     - go get ./...
     - env CGO_ENABLED=1 go build -race -v ./...
   test_script:
+    - echo $PATH
+    - refreshenv
+    - echo $PATH
     - env CGO_ENABLED=1 go test -race -v ./...
   bench_script:
     - go test -run=XXX -bench=. ./...
 
 freebsd_task:
   freebsd_instance:
-    image: freebsd-14-0-release-amd64
+    image: freebsd-14-0-release-amd64-ufs
   env:
     GO111MODULE: on
     GOPATH: /tmp/go

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,6 +43,7 @@ windows_task:
     CIRRUS_WORKING_DIR: C:\golang\src\github.com\${CIRRUS_REPO_FULL_NAME}
   install_script:
     - choco install -y golang
+    - choco install -y mingw  # This installs MinGW which includes gcc
   build_script:
     - go version
     - go get ./...


### PR DESCRIPTION
Github Action for windows was failing because gcc was not installed on windows runner. This fixes this issue by installing mingw onto the windows runner, which will install gcc

Error that this fixes
```
C:\golang\src\github.com\awnumar\memguard>call env CGO_ENABLED=1 go test -race -v ./... 
# runtime/cgo
cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in %PATH%
FAIL	github.com/awnumar/memguard [build failed]
FAIL	github.com/awnumar/memguard/core [build failed]
FAIL	github.com/awnumar/memguard/examples/casting [build failed]
FAIL	github.com/awnumar/memguard/examples/deadlock/x01 [build failed]
FAIL	github.com/awnumar/memguard/examples/socketkey [build failed]
?   	github.com/awnumar/memguard/examples/stdin	[no test files]
?   	github.com/awnumar/memguard/examples/streams	[no test files]
FAIL	github.com/awnumar/memguard/examples/stream [build failed]
FAIL
```