### PR TITLE
Fix concurrency issues leading to panic in Coffer

### DIFF
--- a/core/coffer.go
+++ b/core/coffer.go
@@ -48,12 +48,11 @@ func NewCoffer() *Coffer {
 
 // Init is used to reset the value stored inside a Coffer to a new random 32 byte value, overwriting the old.
 func (s *Coffer) Init() error {
-	if s.Destroyed() {
-		return ErrCofferExpired
-	}
-
 	s.Lock()
 	defer s.Unlock()
+	if s.destroyed() {
+		return ErrCofferExpired
+	}
 
 	if err := Scramble(s.left.Data()); err != nil {
 		return err
@@ -76,14 +75,13 @@ func (s *Coffer) Init() error {
 View returns a snapshot of the contents of a Coffer inside a Buffer. As usual the Buffer should be destroyed as soon as possible after use by calling the Destroy method.
 */
 func (s *Coffer) View() (*Buffer, error) {
-	if s.Destroyed() {
-		return nil, ErrCofferExpired
-	}
-
 	b, _ := NewBuffer(32)
 
 	s.Lock()
 	defer s.Unlock()
+	if s.destroyed() {
+		return nil, ErrCofferExpired
+	}
 
 	// data = hash(right) XOR left
 	h := Hash(s.right.Data())
@@ -100,12 +98,11 @@ func (s *Coffer) View() (*Buffer, error) {
 Rekey is used to re-key a Coffer. Ideally this should be done at short, regular intervals.
 */
 func (s *Coffer) Rekey() error {
-	if s.Destroyed() {
-		return ErrCofferExpired
-	}
-
 	s.Lock()
 	defer s.Unlock()
+	if s.destroyed() {
+		return ErrCofferExpired
+	}
 
 	if err := Scramble(s.rand.Data()); err != nil {
 		return err
@@ -174,6 +171,10 @@ func (s *Coffer) Destroyed() bool {
 	s.Lock()
 	defer s.Unlock()
 
+	return s.destroyed()
+}
+
+func (s *Coffer) destroyed() bool {
 	if s.left == nil || s.right == nil {
 		return true
 	}


### PR DESCRIPTION
There is at least one issue here with lock usage leading to a panic. The code would call `.Destroyed()` then take the lock and assume the coffer is not destroyed, when it can be destroyed after the lock is acquired. This caused a panic in the test I added. This has been refactored to take the lock, check the function `.destroyed()` and then make decisions based off that.